### PR TITLE
Plugin Api generation via ant inside maven

### DIFF
--- a/uis/pom.xml
+++ b/uis/pom.xml
@@ -127,4 +127,49 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>plugin-api</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <version>1.8</version>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <configuration>
+                                    <tasks>
+                                        <patternset id="pluginapi.inc">
+                                            <include name="com/biglybt/pif/**" />
+                                            <include name="com/biglybt/ui/swt/pif/**" />
+                                        </patternset>
+                                        <jar destfile="${project.build.directory}/BiglyBT-${project.version}-pluginapi.jar" level="9" >
+                                            <fileset dir="${project.basedir}/../core/target/classes">
+                                                <patternset refid="pluginapi.inc"/>
+                                            </fileset>
+                                            <fileset dir="${project.build.directory}/classes">
+                                                <patternset refid="pluginapi.inc"/>
+                                            </fileset>
+
+                                            <fileset dir="${project.basedir}/../core/src">
+                                                <patternset refid="pluginapi.inc"/>
+                                            </fileset>
+                                            <fileset dir="${project.basedir}/src">
+                                                <patternset refid="pluginapi.inc"/>
+                                            </fileset>
+                                        </jar>
+                                    </tasks>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/uis/pom.xml
+++ b/uis/pom.xml
@@ -144,6 +144,7 @@
                                         <patternset id="pluginapi.inc">
                                             <include name="com/biglybt/pif/**" />
                                             <include name="com/biglybt/ui/swt/pif/**" />
+                                            <include name="com/biglybt/ui/common/UIInstanceBase.*" />
                                         </patternset>
                                         <jar destfile="${project.build.directory}/BiglyBT-${project.version}-pluginapi.jar" level="9" >
                                             <fileset dir="${project.basedir}/../core/target/classes">


### PR DESCRIPTION
resolves https://github.com/BiglySoftware/BiglyBT/issues/19

Finally I couldn't manage to do it via maven only so it's via ant inside maven :/

I'm sure someone can improve it to get rid of the ant part :)  (At least we don't need to install ant)