### PR TITLE
Update Pom: Don't expose UIInstanceBase class to Plugin Interface.

### DIFF
--- a/uis/pom.xml
+++ b/uis/pom.xml
@@ -144,7 +144,6 @@
                                         <patternset id="pluginapi.inc">
                                             <include name="com/biglybt/pif/**" />
                                             <include name="com/biglybt/ui/swt/pif/**" />
-                                            <include name="com/biglybt/ui/common/UIInstanceBase.*" />
                                         </patternset>
                                         <jar destfile="${project.build.directory}/BiglyBT-${project.version}-pluginapi.jar" level="9" >
                                             <fileset dir="${project.basedir}/../core/target/classes">


### PR DESCRIPTION
https://github.com/BiglySoftware/BiglyBT/commit/4e313f361849cf6fbc385964e80a2b5ae50844b4