### PR TITLE
changed deprecated expression

### DIFF
--- a/uis/pom.xml
+++ b/uis/pom.xml
@@ -93,7 +93,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <dependencyReducedPomLocation>${build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+                            <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
                             <artifactSet>
                                 <excludes>
                                     <exclude>org.eclipse.swt:org.eclipse.swt.win32.win32.x86</exclude>


### PR DESCRIPTION
The expression ${build.directory} is deprecated. Please use ${project.build.directory} instead.