### PR TITLE
azbppluginupdate: Update log format

### DIFF
--- a/core/src/com/biglybt/pifimpl/update/PluginUpdatePlugin.java
+++ b/core/src/com/biglybt/pifimpl/update/PluginUpdatePlugin.java
@@ -773,15 +773,16 @@ PluginUpdatePlugin
 						// the end of current to avoid confusion
 
 					log.log( LoggerChannel.LT_INFORMATION,
-								"    Current: " + az_plugin_version +
+								"Plugin: " + plugin_id + " versions (current=" + az_plugin_version +
 								(comp==0&&sf_plugin_version.endsWith( "_CVS")?"_CVS":"")+
-								", Latest: " + sf_plugin_version + (pi_version_info==null?"":" [" + pi_version_info + "]"));
+								", latest=" + sf_plugin_version + (pi_version_info==null?"":" [" + pi_version_info + "]") + ")");
 
-					checker.reportProgress( "    current=" + az_plugin_version + (comp==0&&sf_plugin_version.endsWith( "_CVS")?"_CVS":"") + ", latest=" + sf_plugin_version );
+					checker.reportProgress( "Plugin: " + plugin_id + "versions (current=" + az_plugin_version +
+								(comp==0&&sf_plugin_version.endsWith( "_CVS")?"_CVS":"") + ", latest=" + sf_plugin_version + ")");
 
 					if ( comp < 0 && ! ( pi_being_checked.getPlugin() instanceof UpdatableComponent)){
 
-							// only update if newer verison + plugin itself doesn't handle
+							// only update if newer version + plugin itself doesn't handle
 							// the update
 
 						String sf_plugin_download	= details.getDownloadURL();


### PR DESCRIPTION
The plugin update checker outputs multiple log lines for each check performed, but those checks are not atomic so their output can be interleaved, leading to confusing output like:

```
[  Downloading: http://plugins.biglybt.com/update/pluginlist3.php]
Checking TimedAutoStart
Checking azupdater
    Current: 2.0.0.1_CVS, Latest: 2.0.0.1_CVS
Checking azutp
    Current: 2.1_CVS, Latest: 2.1_CVS
    Current: 0.6.2_CVS, Latest: 0.6.2_CVS
```

This patch changes the log format so that version-string lines are not assumed to immediately follow the corresponding "Checking" line. Relevant information is included in each line of output.

The above log would instead be formatted:

```
[  Downloading: http://plugins.biglybt.com/update/pluginlist3.php]
Checking TimedAutoStart
Checking azupdater
Plugin: TimedAutoStart versions (current=2.0.0.1_CVS, latest=2.0.0.1_CVS)
Checking azutp
Plugin: azupdater versions (current=2.1_CVS, latest=2.1_CVS)
Plugin: azutp versions (current=0.6.2_CVS, latest=0.6.2_CVS)
```