### PR TITLE
maven-shade-plugin ignores biglybt-core

### DIFF
--- a/uis/pom.xml
+++ b/uis/pom.xml
@@ -104,7 +104,7 @@
                             </artifactSet>
                             <filters>
                                 <filter>
-                                    <artifact>com.giblybt:biglybt-core</artifact>
+                                    <artifact>com.biglybt:biglybt-core</artifact>
                                     <includes>
                                         <include>**</include>
                                     </includes>


### PR DESCRIPTION
    [INFO] --- maven-shade-plugin:3.0.0:shade (default) @ biglybt-ui ---
    [INFO] Including com.biglybt:biglybt-core:jar:1.5.0.1-SNAPSHOT in the shaded jar.
    [INFO] Excluding commons-cli:commons-cli:jar:1.4 from the shaded jar.
    [INFO] Excluding log4j:log4j:jar:1.2.17 from the shaded jar.
    [INFO] No artifact matching filter com.giblybt:biglybt-core

Fix typo in biglybt-core's groupId.