### PR TITLE
Update Allan Crooks files to be GPLv2 or later

### DIFF
--- a/core/src/com/biglybt/pif/PluginState.java
+++ b/core/src/com/biglybt/pif/PluginState.java
@@ -5,7 +5,8 @@
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; version 2 of the License.
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/core/src/com/biglybt/pifimpl/local/PluginStateImpl.java
+++ b/core/src/com/biglybt/pifimpl/local/PluginStateImpl.java
@@ -5,7 +5,8 @@
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; version 2 of the License.
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of


### PR DESCRIPTION
Hi BiglyBT folks!

In auditing Fedora, we discovered that two of the files in the "azureus" package were licensed GPLv2 only, while the rest of the codebase was GPLv2 or later. 

Specifically: 
PluginStateImpl.java
PluginState.java

This is important because azureus (then vuze, and now BiglyBT) makes extensive use of other Java components which are under the Apache 2.0 license. The Apache 2.0 license is compatible with
GPL version 3, but not with GPL version 2. In order to resolve the licensing issue, we need to be able to trigger the "or later" clause.

I reached out to @the-allanc and confirmed that he was the copyright holder for these works. In email (which I am happy to provide copies of, if necessary), he gave permission for those two files to be used under either version 2 of the GPL or (at your option) any later version. He also requested that I push the license change to BiglyBT on his behalf, hence, this PR.