### PR TITLE
Add wrapping to TextViewerWindow (for "...Existing Files")

### DIFF
--- a/uis/src/com/biglybt/ui/swt/TextViewerWindow.java
+++ b/uis/src/com/biglybt/ui/swt/TextViewerWindow.java
@@ -129,7 +129,7 @@ public class TextViewerWindow {
     gridData.horizontalSpan = 3;
     Utils.setLayoutData(label, gridData);
 
-    txtInfo = new Text(shell, SWT.BORDER | SWT.MULTI | SWT.V_SCROLL | SWT.H_SCROLL);
+    txtInfo = new Text(shell, SWT.BORDER | SWT.MULTI | SWT.V_SCROLL | SWT.H_SCROLL | SWT.WRAP);
     gridData = new GridData(  GridData.FILL_BOTH );
     gridData.widthHint = 600;
     gridData.heightHint = 400;


### PR DESCRIPTION
So, I found a way to solve the `Search For Existing Files...` twitching. It's kind of brute-force, but it works.

I just turned wrapping on for the `TextViewerWindow`. 

(Actually, I turned wrapping on for _all_ `TextViewerWindow` instances, since that option wasn't overrideable from the caller. So, I'm not sure what the side effects of that would be; depends where else `TextViewerWindow` is used.)

Like I said, brute-force. Your call on whether it's the _right_ fix. (And I'm fully anticipating that it isn't, so don't hesitate to reject this PR. But I figured maybe it'll trigger some inspiration for a _right_-er fix.) I wanted to report that it _does_ solve the twitching issue, anyway.

Fixes: #545 