### PR TITLE
View > Beta Program: no checkbox

### DIFF
--- a/uis/src/com/biglybt/ui/swt/shells/main/MainMenuV3.java
+++ b/uis/src/com/biglybt/ui/swt/shells/main/MainMenuV3.java
@@ -366,15 +366,14 @@ public class MainMenuV3
 			boolean needsSep = false;
 			boolean enabled = COConfigurationManager.getBooleanParameter("Beta Programme Enabled");
 			if (enabled) {
-				MenuFactory.addMenuItem(viewMenu, SWT.CHECK, PREFIX_V2 + ".view.beta",
-						new Listener() {
-							@Override
-							public void handleEvent(Event event) {
-								MultipleDocumentInterface mdi = UIFunctionsManager.getUIFunctions().getMDI();
-								if (mdi != null) {
-									mdi.showEntryByID(MultipleDocumentInterface.SIDEBAR_SECTION_BETAPROGRAM);
-								}
-							}
+				MenuFactory.addMenuItem(viewMenu, PREFIX_V2 + ".view.beta", new Listener() {
+					@Override
+					public void handleEvent(Event event) {
+						MultipleDocumentInterface mdi = UIFunctionsManager.getUIFunctions().getMDI();
+						if (mdi != null) {
+							mdi.showEntryByID(MultipleDocumentInterface.SIDEBAR_SECTION_BETAPROGRAM);
+						}
+					}
 				});
 				needsSep = true;
 			}


### PR DESCRIPTION
The "Beta Program" option in the View menu displays with a checkbox next to it, but it's not a toggleable item like Side Bar, Plugin Bar, or Search Bar, and the checkbox is never checked even when the Beta Program window/pane is visible.

This removes the `SWT.CHECK` style to eliminate the checkbox.