### PR TITLE
Add 'SHA-1' to 'hash', where it's needed

### DIFF
--- a/core/src/com/biglybt/internat/MessagesBundle.properties
+++ b/core/src/com/biglybt/internat/MessagesBundle.properties
@@ -3395,7 +3395,7 @@ Button.open=Open
 
 plugin.init.load.failed=Error loading plugin '%1' from %2
 plugin.init.load.failed.classmissing=Uninstall the plugin via 'Tools->Plugins->Uninstallation Wizard' and then re-install it.
-v3.MainWindow.search.tooltip=Enter your search terms, magnet link, hash or torrent URL and hit enter!
+v3.MainWindow.search.tooltip=Enter your search terms, magnet link, SHA-1 hash or torrent URL and hit enter!
 
 device.playnow.group=Play Now
 device.playnow.buffer=Buffer size before playback starts [sec]
@@ -3781,7 +3781,7 @@ sidebar.show.options=Show the Options View as a sidebar entry rather than a sepa
 TorrentOptionsView.param.reset.stats=Reset torrent(s) transfer statistics to zero
 ConfigView.label.moveifsamedrive=But only do this when the source and destination are on different file systems
 
-OpenTorrentWindow.pastearea=Enter URL, magnet link, or hash:
+OpenTorrentWindow.pastearea=Enter URL, magnet link, or SHA-1 hash:
 OpenTorrentWindow.checkbox.showAdvanced=Once the torrent is loaded, let me set advanced options, such as file selection and save location.
 
 OpenTorrentFile.column.download=Download?


### PR DESCRIPTION
'SHA-1' should be added to term 'hash', when it's a 'SHA-1 hash', so the user know what kind of hash it is.
Expecting that the user reads in Wikipedia about e.g. Magnet Links, is not really 'nice'.
So: Add 'SHA-1' to 'hash', where it's needed!