### PR TITLE
Fix launching files that contain spaces on Linux

### DIFF
--- a/uis/src/com/biglybt/ui/swt/Utils.java
+++ b/uis/src/com/biglybt/ui/swt/Utils.java
@@ -1473,23 +1473,25 @@ public class Utils
 
 		if (!launched && Constants.isUnix) {
 
-			sFileModified = sFileModified.replaceAll( " ", "\\ " );
+			if (!fallbackLaunch("xdg-open", sFileModified)) {
 
-			if (!fallbackLaunch("xdg-open " + sFileModified)) {
+				Debug.out( "Failed to launch '" + sFileModified + "'" );
 
-				if ( !fallbackLaunch("htmlview " + sFileModified)){
-
-					Debug.out( "Failed to launch '" + sFileModified + "'" );
-				}
 			}
 		}
 	}
 
-	private static boolean fallbackLaunch(String filename) {
+	private static boolean fallbackLaunch(String command, String... args) {
 		try {
-			Runtime.getRuntime().exec(filename);
+			List<String> cmdList = new ArrayList<>();
+			cmdList.add(command);
+			cmdList.addAll(Arrays.asList(args));
+			String[] cmdArray = cmdList.toArray(new String[0]);
+
+			Runtime.getRuntime().exec(cmdArray);
+
 			return true;
-		} catch	(Exception e) {
+		} catch	(Exception ignore) {
 			return false;
 		}
 	}


### PR DESCRIPTION
On Linux, the current escaping doesn't work for files/dirs that have spaces.
The only way that works is explicitly passing `xdg-open` separately from the filename (in an array) to `Runtime.exec(String cmdarray)`.

I also got rid of htmlview as a fallback because xdg-open doesn't ever fail unless it isn't installed. It also opens URLs.

I should note that there's another way of getting xdg-open to work: to URLEncode the filename. This was more problematic as it required making assumptions about what is being opened (if it is already a URL or already encoded, then it would be double-encoded). The current solution seems to work for URLs and files and directories and is the least complex.