### PR TITLE
l10n constants

### DIFF
--- a/core/src.test/com/biglybt/core/internat/MessageTextTest.java
+++ b/core/src.test/com/biglybt/core/internat/MessageTextTest.java
@@ -1,15 +1,16 @@
 package com.biglybt.core.internat;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import com.biglybt.core.util.Constants;
 import com.biglybt.testutil.junit5.DefaultTestCoreConfiguration;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
 
 @ExtendWith(DefaultTestCoreConfiguration.class)
 public class MessageTextTest
@@ -139,6 +140,43 @@ public class MessageTextTest
 		assertThat(twoLinesOfArabicLetters.replace("\n", ""))
 				.isEqualTo(twoArabicLetters);
 	}
+
+	@Test
+	public void defaultKeyIsRegistered() {
+		assertThat(MessageText.getString("base.product.name"))
+				.isEqualTo(Constants.APP_NAME);
+	}
+
+	@ExtendWith(DefaultTestCoreConfiguration.class)
+	static class SubstitutionAlgorithmTests
+	{
+		static final String APP_NAME = Constants.APP_NAME;
+
+		@Test
+		public void singleSubstitution() {
+			String expandableString = "{base.product.name}";
+			assertThat(MessageText.expandValue(expandableString))
+					.isEqualTo(APP_NAME);
+		}
+
+		@Test
+		public void multipleSubstitutions() {
+			String expandableString = "{base.product.name}}{{base.product.name}";
+			assertThat(MessageText.expandValue(expandableString))
+					.isEqualTo(APP_NAME + "}{" + APP_NAME);
+		}
+
+		@Test
+		public void unknownSubstitutionKeyIsLeftUnaltered() {
+			String expandableString = "{no.key.defined}";
+			assertThat(MessageText.expandValue(expandableString))
+					.isEqualTo("{no.key.defined}");
+		}
+
+
+
+	}
+
 
 
 }

--- a/core/src/com/biglybt/internat/MessagesBundle.properties
+++ b/core/src/com/biglybt/internat/MessagesBundle.properties
@@ -1,5 +1,4 @@
 #There is a plugin to help with internationalizing these bundles
-base.product.name=BiglyBT
 MainWindow.menu.file.open.torrent=Torrent File...
 MainWindow.menu.file.open.torrent.keybinding=Meta+O
 MainWindow.menu.file=&File

--- a/uis/src/com/biglybt/ui/swt/shells/GCStringPrinter.java
+++ b/uis/src/com/biglybt/ui/swt/shells/GCStringPrinter.java
@@ -43,7 +43,7 @@ import com.biglybt.ui.swt.imageloader.ImageLoader;
  */
 public class GCStringPrinter
 {
-	private static final String ELLIPSIS = "\u2026";	// "..."
+	private static final char ELLIPSIS = '\u2026';	// "..." - same as &hellip; in html
 	
 	private static final boolean DEBUG = false;
 


### PR DESCRIPTION
I tried the exercise of removing the constant value "BiglyBT" from the message bundles.
This is a system wide constant anyhow and shouldn't be translated into something different.

What I discovered was that this value could only be used for expansion and not on itself. 
This improvement introduces some default keys wich are expandable (like the others).

I am treating the wiki URLs are the same for all languages, at least that's how it currently is.  
If it were to be updated, then one had to call the method `updateProductName()`

Unit-tests are added for this change.
