### PR TITLE
code cleanup: removed duplicate if-conditions

### DIFF
--- a/core/src/com/biglybt/core/disk/impl/DiskManagerImpl.java
+++ b/core/src/com/biglybt/core/disk/impl/DiskManagerImpl.java
@@ -576,14 +576,6 @@ DiskManagerImpl
 
                 // bail out if broken in the meantime
                 // state will be "faulty" if the allocation process is interrupted by a stop
-
-            return;
-        }
-
-        if ( getState() == FAULTY  ){
-
-                // bail out if broken in the meantime
-
             return;
         }
 

--- a/core/src/com/biglybt/core/helpers/TorrentFolderWatcher.java
+++ b/core/src/com/biglybt/core/helpers/TorrentFolderWatcher.java
@@ -148,11 +148,6 @@ public class TorrentFolderWatcher {
 							break;
 						}
 
-						if ( remaining < 250 ){
-
-							remaining = 250;
-						}
-
 						wait_sem.reserve( remaining );
 					}
 


### PR DESCRIPTION
Running an inspection found two cases of duplicate if conditions. 