### PR TITLE
Code cleanup: removed relic SelectorGuard handling

### DIFF
--- a/core/src/com/biglybt/core/config/impl/ConfigurationChecker.java
+++ b/core/src/com/biglybt/core/config/impl/ConfigurationChecker.java
@@ -383,19 +383,6 @@ ConfigurationChecker
 	    }else {  //this is a pre-existing installation, called every time after first
 
 
-
-	    	if // disable safe selector mode enabled at some point in the past if we're on java 6 or higher and/or not on windows
-	    	(	COConfigurationManager.getBooleanParameter("network.tcp.enable_safe_selector_mode")
-	    		&& !(Constants.isWindows &&
-	    			(Constants.JAVA_VERSION.startsWith("1.4") ||
-	    			Constants.JAVA_VERSION.startsWith("1.5"))
-	    		)
-	    	)
-	    	{
-	    		COConfigurationManager.removeParameter("network.tcp.enable_safe_selector_mode");
-	    		changed = true;
-	    	}
-
 	    	// transition from tracker-only port override to global port override
 	    	if(COConfigurationManager.doesParameterNonDefaultExist("TCP.Announce.Port"))
 	    	{

--- a/core/src/com/biglybt/core/config/impl/ConfigurationDefaults.java
+++ b/core/src/com/biglybt/core/config/impl/ConfigurationDefaults.java
@@ -671,7 +671,6 @@ public class ConfigurationDefaults {
     def.put( "filechannel.rt.buffer.pieces", new Long( 5 ));
 
     def.put( "BT Request Max Block Size", new Long(65536));
-    def.put( "network.tcp.enable_safe_selector_mode", FALSE );
     def.put( "network.tcp.safe_selector_mode.chunk_size", SIXTY );
 
     def.put( "network.transport.encrypted.require", FALSE );

--- a/core/src/com/biglybt/core/config/impl/ConfigurationDefaults.java
+++ b/core/src/com/biglybt/core/config/impl/ConfigurationDefaults.java
@@ -41,11 +41,6 @@ import com.biglybt.platform.PlatformManager;
 import com.biglybt.platform.PlatformManagerFactory;
 
 /**
- *
- * @author  Tobias Minich
- */
-
-/**
  * Some (proposed) option naming conventions:
  * - Starts with a general identifier
  *   General_ for, well, general things =)
@@ -61,6 +56,8 @@ import com.biglybt.platform.PlatformManagerFactory;
  *   special validity checks in the webinterface option parsing code.
  *   (Namely they are created if they don't exist and the option isn't changed
  *   with a logged error if a normal file of the same name exists)
+ *
+ * @author Tobias Minich
  */
 
 public class ConfigurationDefaults {
@@ -671,7 +668,6 @@ public class ConfigurationDefaults {
     def.put( "filechannel.rt.buffer.pieces", new Long( 5 ));
 
     def.put( "BT Request Max Block Size", new Long(65536));
-    def.put( "network.tcp.safe_selector_mode.chunk_size", SIXTY );
 
     def.put( "network.transport.encrypted.require", FALSE );
     def.put( "network.transport.encrypted.min_level", "RC4" );

--- a/core/src/com/biglybt/core/networkmanager/VirtualChannelSelector.java
+++ b/core/src/com/biglybt/core/networkmanager/VirtualChannelSelector.java
@@ -23,44 +23,22 @@ import java.nio.channels.SelectionKey;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.nio.channels.spi.AbstractSelectableChannel;
-import java.util.*;
 
-import com.biglybt.core.config.COConfigurationManager;
-import com.biglybt.core.logging.LogEvent;
-import com.biglybt.core.logging.LogIDs;
-import com.biglybt.core.logging.Logger;
 import com.biglybt.core.networkmanager.impl.tcp.VirtualChannelSelectorImpl;
-import com.biglybt.core.util.AEMonitor;
-import com.biglybt.core.util.Debug;
 
 
 public class VirtualChannelSelector {
-  private static final LogIDs LOGID = LogIDs.NWMAN;
   public static final int OP_ACCEPT  = SelectionKey.OP_ACCEPT;
   public static final int OP_CONNECT  = SelectionKey.OP_CONNECT;
   public static final int OP_READ   = SelectionKey.OP_READ;
   public static final int OP_WRITE  = SelectionKey.OP_WRITE;
 
-  private boolean SAFE_SELECTOR_MODE_ENABLED = TEST_SAFE_MODE;
-
-  private static final boolean TEST_SAFE_MODE	= false;
-
-  private static final int MAX_CHANNELS_PER_SAFE_SELECTOR	= COConfigurationManager.getIntParameter( "network.tcp.safe_selector_mode.chunk_size" );
-
-  private static final int MAX_SAFEMODE_SELECTORS = 20000 / MAX_CHANNELS_PER_SAFE_SELECTOR;
-
   private final String		name;
-
-  private VirtualChannelSelectorImpl selector_impl;
+  private final VirtualChannelSelectorImpl selector_impl;
 
   private volatile boolean	destroyed;
 
-  //ONLY USED IN FAULTY MODE
-  private HashMap<VirtualChannelSelectorImpl,ArrayList<AbstractSelectableChannel>> selectors;
-  private HashSet<VirtualChannelSelectorImpl> selectors_keyset_cow;
-  private AEMonitor selectors_mon;
   private final int op;
-  private final boolean pause;
 
   private boolean randomise_keys;
 
@@ -71,39 +49,16 @@ public class VirtualChannelSelector {
    * @param pause_after_select whether or not to auto-disable interest op after select
    */
   public VirtualChannelSelector( String name, int interest_op, boolean pause_after_select ) {
-	this.name = name;
+		this.name = name;
     this.op = interest_op;
-    this.pause = pause_after_select;
 
-    if( SAFE_SELECTOR_MODE_ENABLED ) {
-      initSafeMode();
-    }
-    else {
-      selector_impl = new VirtualChannelSelectorImpl( this, op, pause, randomise_keys );
-      selectors = null;
-      selectors_keyset_cow	= null;
-      selectors_mon = null;
-    }
+	  selector_impl = new VirtualChannelSelectorImpl(this, op, pause_after_select, randomise_keys);
   }
 
   public String
   getName()
   {
 	  return( name );
-  }
-
-  private void initSafeMode() {
-	//System.out.println( "***************** SAFE SOCKET SELECTOR MODE ENABLED *****************" );
-
-    if (Logger.isEnabled()) {
-    	Logger.log(new LogEvent(LOGID, "***************** SAFE SOCKET SELECTOR MODE ENABLED *****************"));
-    }
-
-    selector_impl = null;
-    selectors = new HashMap<>();
-    selectors_mon = new AEMonitor( "VirtualChannelSelector:FM" );
-    selectors.put( new VirtualChannelSelectorImpl( this, op, pause, randomise_keys ), new ArrayList<AbstractSelectableChannel>() );
-    selectors_keyset_cow = new HashSet<>(selectors.keySet());
   }
 
 
@@ -127,133 +82,21 @@ public class VirtualChannelSelector {
    * @param attachment object to be passed back with listener notification
    */
   protected void registerSupport( AbstractSelectableChannel channel, VirtualAbstractSelectorListener listener, Object attachment ) {
-    if( SAFE_SELECTOR_MODE_ENABLED ) {
-      try{  selectors_mon.enter();
-      	//System.out.println( "register - " + channel.hashCode()  + " - " + Debug.getCompressedStackTrace());
-        for( Map.Entry<VirtualChannelSelectorImpl, ArrayList<AbstractSelectableChannel>> entry: selectors.entrySet()) {
-
-          VirtualChannelSelectorImpl 			sel 		= entry.getKey();
-          ArrayList<AbstractSelectableChannel> 	channels 	= entry.getValue();
-
-          if( channels.size() >= ( TEST_SAFE_MODE?0:MAX_CHANNELS_PER_SAFE_SELECTOR )) {
-
-         	  // it seems that we have a bug somewhere where a selector is being registered
-        	  // but not cancelled on close. As an interim fix scan channels and remove any
-        	  // closed ones
-
-        	  Iterator<AbstractSelectableChannel>	chan_it = channels.iterator();
-
-        	  while( chan_it.hasNext()){
-
-        		  AbstractSelectableChannel	chan = chan_it.next();
-
-        		  if ( !chan.isOpen()){
-
-        			  Debug.out( "Selector '" + getName() + "' - removing orphaned safe channel registration" );
-
-        			  chan_it.remove();
-        		  }
-        	  }
-          }
-
-          if( channels.size() < MAX_CHANNELS_PER_SAFE_SELECTOR ) {  //there's room in the current selector
-
-            sel.register( channel, listener, attachment );
-            channels.add( channel );
-
-            return;
-          }
-        }
-
-        //we couldnt find room in any of the existing selectors, so start up a new one if allowed
-
-        //max limit to the number of Selectors we are allowed to create
-        if( selectors.size() >= MAX_SAFEMODE_SELECTORS ) {
-      	  String msg = "Error: MAX_SAFEMODE_SELECTORS reached [" +selectors.size()+ "], no more socket channels can be registered. Too many peer connections.";
-      	  Debug.out( msg );
-      	  selectFailure( listener, channel, attachment, new Throwable( msg ) );  //reject registration
-      	  return;
-        }
-
-        if ( destroyed ){
-          String	msg = "socket registered after controller destroyed";
-       	  Debug.out( msg );
-      	  selectFailure( listener, channel, attachment, new Throwable( msg ) );  //reject registration
-      	  return;
-        }
-
-        VirtualChannelSelectorImpl sel = new VirtualChannelSelectorImpl( this, op, pause , randomise_keys);
-
-        ArrayList<AbstractSelectableChannel> chans = new ArrayList<>();
-
-        selectors.put( sel, chans );
-
-        sel.register( channel, listener, attachment );
-
-        chans.add( channel );
-
-        selectors_keyset_cow = new HashSet<>(selectors.keySet());
-      }
-      finally{ selectors_mon.exit();  }
-    }
-    else {
-      selector_impl.register( channel, listener, attachment );
-    }
+	  selector_impl.register(channel, listener, attachment);
   }
 
 
 
   public boolean isPaused( AbstractSelectableChannel channel ) {
-	    if( SAFE_SELECTOR_MODE_ENABLED ) {
-	      try{  selectors_mon.enter();
-	      	//System.out.println( "pause - " + channel.hashCode() + " - " + Debug.getCompressedStackTrace());
-	      for( Map.Entry<VirtualChannelSelectorImpl, ArrayList<AbstractSelectableChannel>> entry: selectors.entrySet()) {
-
-	          VirtualChannelSelectorImpl 			sel 		= entry.getKey();
-	          ArrayList<AbstractSelectableChannel> 	channels 	= entry.getValue();
-
-	          if( channels.contains( channel ) ) {
-	            return( sel.isPaused( channel ));
-	          }
-	        }
-
-	        Debug.out( "isPaused():: channel not found!" );
-	      }
-	      finally{ selectors_mon.exit();  }
-	      
-	      return( false );
-	    }
-	    else {
-	      return( selector_impl.isPaused( channel ));
-	    }
-	  }
+	  return selector_impl.isPaused(channel);
+  }
   
   /**
    * Pause selection operations for the given channel
    * @param channel to pause
    */
   public void pauseSelects( AbstractSelectableChannel channel ) {
-    if( SAFE_SELECTOR_MODE_ENABLED ) {
-      try{  selectors_mon.enter();
-      	//System.out.println( "pause - " + channel.hashCode() + " - " + Debug.getCompressedStackTrace());
-      for( Map.Entry<VirtualChannelSelectorImpl, ArrayList<AbstractSelectableChannel>> entry: selectors.entrySet()) {
-
-          VirtualChannelSelectorImpl 			sel 		= entry.getKey();
-          ArrayList<AbstractSelectableChannel> 	channels 	= entry.getValue();
-
-          if( channels.contains( channel ) ) {
-            sel.pauseSelects( channel );
-            return;
-          }
-        }
-
-        Debug.out( "pauseSelects():: channel not found!" );
-      }
-      finally{ selectors_mon.exit();  }
-    }
-    else {
-      selector_impl.pauseSelects( channel );
-    }
+	  selector_impl.pauseSelects(channel);
   }
 
 
@@ -263,78 +106,20 @@ public class VirtualChannelSelector {
    * @param channel to resume
    */
   public void resumeSelects( AbstractSelectableChannel channel ) {
-    if( SAFE_SELECTOR_MODE_ENABLED ) {
-      try{  selectors_mon.enter();
-      	//System.out.println( "resume - " + channel.hashCode() + " - " + Debug.getCompressedStackTrace());
-      for( Map.Entry<VirtualChannelSelectorImpl, ArrayList<AbstractSelectableChannel>> entry: selectors.entrySet()) {
-
-          VirtualChannelSelectorImpl 			sel 		= entry.getKey();
-          ArrayList<AbstractSelectableChannel> 	channels 	= entry.getValue();
-
-          if( channels.contains( channel ) ) {
-            sel.resumeSelects( channel );
-            return;
-          }
-        }
-
-        Debug.out( "resumeSelects():: channel not found!" );
-      }
-      finally{ selectors_mon.exit();  }
-    }
-    else {
-      selector_impl.resumeSelects( channel );
-    }
+	  selector_impl.resumeSelects(channel);
   }
 
 
   public boolean isRegistered( AbstractSelectableChannel channel ) {
-	    if( SAFE_SELECTOR_MODE_ENABLED ) {
-	      try{  selectors_mon.enter();
-	      	//System.out.println( "pause - " + channel.hashCode() + " - " + Debug.getCompressedStackTrace());
-	      for( Map.Entry<VirtualChannelSelectorImpl, ArrayList<AbstractSelectableChannel>> entry: selectors.entrySet()) {
+	  return selector_impl.isRegistered(channel);
+  }
 
-	          VirtualChannelSelectorImpl 			sel 		= entry.getKey();
-	          ArrayList<AbstractSelectableChannel> 	channels 	= entry.getValue();
-
-	          if( channels.contains( channel ) ) {
-	            return( sel.isRegistered( channel ));
-	          }
-	        }
-
-	        Debug.out( "isRegistered():: channel not found!" );
-	      }
-	      finally{ selectors_mon.exit();  }
-	      
-	      return( false );
-	    }
-	    else {
-	      return( selector_impl.isRegistered( channel ));
-	    }
-	  }
   /**
    * Cancel the selection operations for the given channel.
    * @param channel channel originally registered
    */
   public void cancel( AbstractSelectableChannel channel ) {
-    if( SAFE_SELECTOR_MODE_ENABLED ) {
-      try{  selectors_mon.enter();
-      	//System.out.println( "cancel - " + channel.hashCode()  + " - " + Debug.getCompressedStackTrace());
-      for( Map.Entry<VirtualChannelSelectorImpl, ArrayList<AbstractSelectableChannel>> entry: selectors.entrySet()) {
-
-          VirtualChannelSelectorImpl 			sel 		= entry.getKey();
-          ArrayList<AbstractSelectableChannel> 	channels 	= entry.getValue();
-
-          if( channels.remove( channel ) ) {
-            sel.cancel( channel );
-            return;
-          }
-        }
-      }
-      finally{ selectors_mon.exit();  }
-    }
-    else {
-      if( selector_impl != null )  selector_impl.cancel( channel );
-    }
+	  selector_impl.cancel(channel);
   }
 
   public void
@@ -343,18 +128,8 @@ public class VirtualChannelSelector {
   {
 	  randomise_keys = _rk;
 
-	    if( SAFE_SELECTOR_MODE_ENABLED ) {
-	      try{  selectors_mon.enter();
-	        for( VirtualChannelSelectorImpl sel: selectors.keySet()){
-	        	sel.setRandomiseKeys( randomise_keys );
-	        }
-	      }
-	      finally{ selectors_mon.exit();  }
-	    }
-	    else {
-	      if( selector_impl != null )  selector_impl.setRandomiseKeys( randomise_keys );
-	    }
-	  }
+	  selector_impl.setRandomiseKeys(randomise_keys);
+  }
 
   /**
    * Run a virtual select() operation, with the given selection timeout value;
@@ -364,37 +139,6 @@ public class VirtualChannelSelector {
    * @return number of sockets selected
    */
   public int select(long timeout) {
-    if( SAFE_SELECTOR_MODE_ENABLED ) {
-      boolean	was_destroyed = destroyed;
-
-      try{
-	      int count = 0;
-
-	      for( VirtualChannelSelectorImpl sel: selectors_keyset_cow ){
-
-	        count += sel.select( timeout );
-	      }
-
-	      return count;
-
-      }finally{
-
-    	  if ( was_destroyed ){
-
-    		  // destruction process requires select op after destroy...
-
-   			 try{
-   				 selectors_mon.enter();
-
-	 		     selectors.clear();
-			     selectors_keyset_cow = new HashSet<>();
-
-   			 }finally{
-   				 selectors_mon.exit();
-   			 }
-    	  }
-      }
-    }
 
     return selector_impl.select( timeout );
   }
@@ -403,15 +147,7 @@ public class VirtualChannelSelector {
   {
 	  destroyed	= true;
 
-	  if ( SAFE_SELECTOR_MODE_ENABLED ){
-
-	      for( VirtualChannelSelectorImpl sel: selectors_keyset_cow ){
-
-	        sel.destroy();
-	     }
-	  }else{
-		  selector_impl.destroy();
-	  }
+	  selector_impl.destroy();
   }
 
   public boolean
@@ -419,8 +155,6 @@ public class VirtualChannelSelector {
   {
 	  return( destroyed );
   }
-
-  public boolean isSafeSelectionModeEnabled() {  return SAFE_SELECTOR_MODE_ENABLED;  }
 
   public boolean
   selectSuccess(

--- a/core/src/com/biglybt/core/networkmanager/VirtualChannelSelector.java
+++ b/core/src/com/biglybt/core/networkmanager/VirtualChannelSelector.java
@@ -41,7 +41,7 @@ public class VirtualChannelSelector {
   public static final int OP_READ   = SelectionKey.OP_READ;
   public static final int OP_WRITE  = SelectionKey.OP_WRITE;
 
-  private boolean SAFE_SELECTOR_MODE_ENABLED = TEST_SAFE_MODE || COConfigurationManager.getBooleanParameter( "network.tcp.enable_safe_selector_mode" );
+  private boolean SAFE_SELECTOR_MODE_ENABLED = TEST_SAFE_MODE;
 
   private static final boolean TEST_SAFE_MODE	= false;
 
@@ -421,14 +421,6 @@ public class VirtualChannelSelector {
   }
 
   public boolean isSafeSelectionModeEnabled() {  return SAFE_SELECTOR_MODE_ENABLED;  }
-
-  public void enableSafeSelectionMode() {
-    if( !SAFE_SELECTOR_MODE_ENABLED ) {
-      SAFE_SELECTOR_MODE_ENABLED = true;
-      COConfigurationManager.setParameter( "network.tcp.enable_safe_selector_mode", true );
-      initSafeMode();
-    }
-  }
 
   public boolean
   selectSuccess(

--- a/core/src/com/biglybt/core/networkmanager/impl/tcp/VirtualChannelSelectorImpl.java
+++ b/core/src/com/biglybt/core/networkmanager/impl/tcp/VirtualChannelSelectorImpl.java
@@ -320,27 +320,7 @@ public class VirtualChannelSelectorImpl {
       }
 
 
-      selector_guard = new SelectorGuard( type, new SelectorGuard.GuardListener() {
-        @Override
-        public boolean safeModeSelectEnabled() {
-          return parent.isSafeSelectionModeEnabled();
-        }
-
-        @Override
-        public void spinDetected() {
-          closeExistingSelector();
-          try {  Thread.sleep( 1000 );  }catch( Throwable x ) {x.printStackTrace();}
-          parent.enableSafeSelectionMode();
-        }
-
-        @Override
-        public void failureDetected() {
-          try {  Thread.sleep( 10000 );  }catch( Throwable x ) {x.printStackTrace();}
-          closeExistingSelector();
-          try {  Thread.sleep( 1000 );  }catch( Throwable x ) {x.printStackTrace();}
-          selector = openNewSelector();
-        }
-      });
+      selector_guard = new SelectorGuard( type);
 
       selector = openNewSelector();
     }
@@ -911,9 +891,7 @@ public class VirtualChannelSelectorImpl {
     	  }
       }
 
-      boolean	randy = randomise_keys;
-
-      if ( randy ){
+	    if (randomise_keys){
 
     	  Collections.shuffle( ready_keys );
       }


### PR DESCRIPTION
The "safe selector mode" was a workaround for Java 1.4/1.5 under Windows.

When this particular workaround detected a spin, then and only then the property `"network.tcp.enable_safe_selector_mode"` would be set to `true`.

The above property was reset to `false` after a start/restart when the combo (operating system + java version) was different then for this workaround.


I'm leaving this as a work in progres (wip) for discussion.

