### PR TITLE
Update gitignore from templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,19 @@
 # Created by .ignore support plugin (hsz.mobi)
 ### JetBrains template
-# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
-# User-specific stuff:
+# User-specific stuff
 .idea/**/workspace.xml
 .idea/**/tasks.xml
-.idea/dictionaries
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
 
-# Sensitive or high-churn files:
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
 .idea/**/dataSources/
 .idea/**/dataSources.ids
 .idea/**/dataSources.xml
@@ -16,21 +21,31 @@
 .idea/**/sqlDataSources.xml
 .idea/**/dynamic.xml
 .idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
 
-# Gradle:
+# Gradle
 .idea/**/gradle.xml
 .idea/**/libraries
 
-# Mongo Explorer plugin:
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
 .idea/**/mongoSettings.xml
 
-## File-based project format:
+# File-based project format
 *.iws
 
-## Plugin-specific files:
-
 # IntelliJ
-/out/
+out/
 
 # mpeltonen/sbt-idea plugin
 .idea_modules/
@@ -38,12 +53,20 @@
 # JIRA plugin
 atlassian-ide-plugin.xml
 
+# Cursive Clojure plugin
+.idea/replstate.xml
+
 # Crashlytics plugin (for Android Studio and IntelliJ)
 com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 fabric.properties
 
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
 
 ### Java template
 # Compiled class file
@@ -58,6 +81,16 @@ fabric.properties
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 
+# Package Files #
+*.war
+*.nar
+*.ear
+*.tar.gz
+*.rar
+# We need these for checked-in packages like SWT (/uis/lib/)
+# *.jar
+# *.zip
+
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
@@ -66,7 +99,6 @@ hs_err_pid*
 
 .metadata
 bin/
-/bin/
 tmp/
 *.tmp
 *.bak
@@ -92,8 +124,8 @@ local.properties
 # CDT-specific (C/C++ Development Tooling)
 .cproject
 
-# JDT-specific (Eclipse Java Development Tools)
-.classpath
+# CDT- autotools
+.autotools
 
 # Java annotation processor (APT)
 .factorypath
@@ -116,10 +148,25 @@ local.properties
 # Code Recommenders
 .recommenders/
 
+# Annotation Processing
+.apt_generated/
+
 # Scala IDE specific (Scala & Java development for Eclipse)
 .cache-main
 .scala_dependencies
 .worksheet
+
+### Maven template
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+.mvn/wrapper/maven-wrapper.jar
 
 ## Our entries
 core/core.iml
@@ -133,9 +180,6 @@ core/lib/libWIN32Access/ipch/
 /uis/src/tux/
 *.DS_Store
 /build/
-
-#maven
-/target
 
 Bigly*.jar
 

--- a/.gitignore
+++ b/.gitignore
@@ -180,6 +180,7 @@ core/lib/libWIN32Access/ipch/
 /uis/src/tux/
 *.DS_Store
 /build/
+.classpath
 
 Bigly*.jar
 


### PR DESCRIPTION
The master .gitignore was originally generated from GitHub's templates at https://github.com/github/gitignore but had fallen out of date. This syncs up with the changes there, and adds in the `Maven.gitignore` template as well.

The official `Java.gitignore` template excluded all packaged files, including .jar and .zip which the repo does contain (e.g. the SWT packages in `uis/lib/`), so I commented those out with a note.

Had no effect on the `git status` output in my local clone, but that's as it should be really.