### PR TITLE
Code cleanup: mitigated UnsupportedEncodingException for String creations

### DIFF
--- a/core/src.test/com/biglybt/core/util/Base32Test.java
+++ b/core/src.test/com/biglybt/core/util/Base32Test.java
@@ -1,0 +1,35 @@
+package com.biglybt.core.util;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+public class Base32Test
+{
+
+	@Test
+	public void encodeInvalidCharsThrowsNoException() {
+		assertThatCode(() -> Base32.encode(new byte[]{(byte) 0xc3, (byte)0x28}))
+				.describedAs("Invalid 2 Octet Sequence: \\xc3\\x28")
+				.doesNotThrowAnyException();
+	}
+
+	@Test
+	public void decodeInvalidCharsThrowsNoException() {
+		assertThatCode(() -> Base32.decode(new String(new byte[]{(byte)0xc3, (byte)0x28}, StandardCharsets.UTF_8)))
+				.describedAs("Invalid 2 Octet Sequence: \\xc3\\x28")
+				.doesNotThrowAnyException();
+	}
+
+
+
+	@Test
+	public void encodeControlCharsThrowsNoException() {
+		assertThatCode(() -> Base32.encode(new byte[]{(byte) 0x00, (byte) 0x01, (byte) 0x02}))
+				.describedAs("Control chars: \\x00\\x01\\x02")
+				.doesNotThrowAnyException();
+	}
+
+}

--- a/core/src/com/biglybt/core/backup/impl/BackupManagerImpl.java
+++ b/core/src/com/biglybt/core/backup/impl/BackupManagerImpl.java
@@ -997,17 +997,11 @@ BackupManagerImpl
 				mods += patch((List)value, from, to );
 
 			}else if ( value instanceof byte[] ){
+				String str = new String((byte[]) value, Constants.UTF_8);
 
-				try{
-					String	str = new String((byte[])value, "UTF-8" );
-
-					if ( str.startsWith( from )){
-
-						new_value = to + str.substring( from.length());
-
-						mods++;
-					}
-				}catch( Throwable e ){
+				if (str.startsWith(from)) {
+					new_value = to + str.substring(from.length());
+					mods++;
 				}
 			}
 
@@ -1058,17 +1052,11 @@ BackupManagerImpl
 				mods += patch((List)entry, from , to );
 
 			}else if ( entry instanceof byte[] ){
+				String str = new String((byte[]) entry, Constants.UTF_8);
 
-				try{
-					String	str = new String((byte[])entry, "UTF-8" );
-
-					if ( str.startsWith( from )){
-
-						list.set( i, to + str.substring( from.length()));
-
-						mods++;
-					}
-				}catch( Throwable e ){
+				if (str.startsWith(from)) {
+					list.set(i, to + str.substring(from.length()));
+					mods++;
 				}
 			}
 		}

--- a/core/src/com/biglybt/core/config/impl/ConfigurationManager.java
+++ b/core/src/com/biglybt/core/config/impl/ConfigurationManager.java
@@ -827,13 +827,8 @@ ConfigurationManager
 
 	  }else if ( o_value instanceof byte[] ){
 
-		  try{
-			  value = new String((byte[])o_value, "UTF-8" );
+			value = new String((byte[]) o_value, Constants.UTF_8);
 
-		  }catch( UnsupportedEncodingException e ){
-
-			  value = null;
-		  }
 	  }else{
 
 		  value = String.valueOf( o_value );
@@ -1339,19 +1334,12 @@ ConfigurationManager
 		Object	value	= propertiesMap.get(key);
 
 		if ( value instanceof byte[] ){
-
-			try{
-				value = new String((byte[])value, "UTF-8" );
-
-			}catch( Throwable e ){
-
-			}
+				value = new String((byte[]) value, Constants.UTF_8);
 		}
 
 		if ( value instanceof String ){
 
 			if (((String)value).toLowerCase( Locale.US ).endsWith( ".b32.i2p" )){
-
 				return( true );
 			}
 		}

--- a/core/src/com/biglybt/core/content/RelatedContentManager.java
+++ b/core/src/com/biglybt/core/content/RelatedContentManager.java
@@ -4398,19 +4398,11 @@ RelatedContentManager
 			int	tag_len = bytes[pos++]&0x000000ff;
 
 			if ( tag_len > MAX_TAG_LENGTH ){
-
 				break;
 			}
 
-			try{
-				tags.add( new String( bytes, pos, tag_len, "UTF-8" ));
-
-				pos += tag_len;
-
-			}catch( Throwable e ){
-
-				break;
-			}
+			tags.add(new String(bytes, pos, tag_len, Constants.UTF_8));
+			pos += tag_len;
 		}
 
 		if ( tags.size() == 0 ){

--- a/core/src/com/biglybt/core/custom/impl/CustomizationManagerImpl.java
+++ b/core/src/com/biglybt/core/custom/impl/CustomizationManagerImpl.java
@@ -505,14 +505,13 @@ CustomizationManagerImpl
 		throws CustomizationException
 	{
 		try{
-			String	name 	= new String((byte[])map.get( "name" ), "UTF-8" );
 
-			String	version = new String((byte[])map.get( "version" ), "UTF-8" );
-
+			String version = new String((byte[]) map.get("version"), Constants.UTF_8);
 			if ( !Constants.isValidVersionFormat( version )){
-
 				throw( new CustomizationException( "Invalid version specification: " + version ));
 			}
+
+			String name = new String((byte[]) map.get("name"), Constants.UTF_8);
 
 			byte[]	data = (byte[])map.get( "data" );
 

--- a/core/src/com/biglybt/core/devices/impl/DeviceImpl.java
+++ b/core/src/com/biglybt/core/devices/impl/DeviceImpl.java
@@ -1701,22 +1701,13 @@ DeviceImpl
 	{
 		synchronized( persistent_properties ){
 
-			try{
-				byte[]	value = (byte[])persistent_properties.get( prop );
+			byte[] value = (byte[]) persistent_properties.get(prop);
 
-				if ( value == null ){
-
-					return( def );
-				}
-
-				return( new String( value, "UTF-8" ));
-
-			}catch( Throwable e ){
-
-				Debug.printStackTrace(e);
-
-				return( def );
+			if (value == null) {
+				return def;
 			}
+
+			return new String(value, Constants.UTF_8);
 		}
 	}
 
@@ -1733,22 +1724,14 @@ DeviceImpl
 
 			if ( !existing.equals( value )){
 
-				try{
-					if ( value == null ){
+				if (value == null) {
+					persistent_properties.remove(prop);
 
-						persistent_properties.remove( prop );
-
-					}else{
-
-						persistent_properties.put( prop, value.getBytes( "UTF-8" ));
-					}
-
-					dirty = true;
-
-				}catch( Throwable e ){
-
-					Debug.printStackTrace(e);
+				} else {
+					persistent_properties.put(prop, value.getBytes(Constants.UTF_8));
 				}
+
+				dirty = true;
 			}
 		}
 
@@ -2030,31 +2013,20 @@ DeviceImpl
 	{
 		synchronized( persistent_properties ){
 
-			try{
-				List<byte[]>	values = (List<byte[]>)persistent_properties.get( prop );
+			List<byte[]> values = (List<byte[]>) persistent_properties.get(prop);
 
-				if ( values == null ){
-
-					return( new String[0] );
-				}
-
-				String[]	res = new String[values.size()];
-
-				int	pos = 0;
-
-				for (byte[] value: values ){
-
-					res[pos++] = new String( value, "UTF-8" );
-				}
-
-				return( res );
-
-			}catch( Throwable e ){
-
-				Debug.printStackTrace(e);
-
-				return( new String[0] );
+			if (values == null) {
+				return new String[0];
 			}
+
+			String[] res = new String[values.size()];
+
+			int pos = 0;
+			for (byte[] value : values) {
+				res[pos++] = new String(value, Constants.UTF_8);
+			}
+
+			return res;
 		}
 	}
 
@@ -2066,27 +2038,18 @@ DeviceImpl
 		boolean dirty = false;
 
 		synchronized( persistent_properties ){
+			List<byte[]> values_list = new ArrayList<>(values.length);
 
-			try{
-				List<byte[]> values_list = new ArrayList<>();
-
-				for (String value: values ){
-
-					values_list.add( value.getBytes( "UTF-8" ));
-				}
-
-				persistent_properties.put( prop, values_list );
-
-				dirty = true;
-
-			}catch( Throwable e ){
-
-				Debug.printStackTrace(e);
+			for (String value : values) {
+				values_list.add(value.getBytes(Constants.UTF_8));
 			}
+
+			persistent_properties.put(prop, values_list);
+
+			dirty = true;
 		}
 
-		if ( dirty ){
-
+		if (dirty) {
 			setDirty();
 		}
 	}

--- a/core/src/com/biglybt/core/devices/impl/DeviceManagerUPnPImpl.java
+++ b/core/src/com/biglybt/core/devices/impl/DeviceManagerUPnPImpl.java
@@ -35,6 +35,7 @@ import com.biglybt.core.devices.DeviceMediaRenderer;
 import com.biglybt.core.devices.TranscodeTarget;
 import com.biglybt.core.util.AEThread2;
 import com.biglybt.core.util.Base32;
+import com.biglybt.core.util.Constants;
 import com.biglybt.core.util.Debug;
 import com.biglybt.core.util.GeneralUtils;
 import com.biglybt.core.util.UUIDGenerator;
@@ -919,15 +920,7 @@ DeviceManagerUPnPImpl
 				// be used as a key in a bencoded map
 				// migrated from prefix of "devices.upnp.uid." to "devices.upnp.uid2."
 
-			String un_key;
-
-			try{
-				un_key = Base32.encode( unique_name.getBytes( "UTF-8" ));
-
-			}catch( Throwable e ){
-
-				un_key = Base32.encode( unique_name.getBytes());
-			}
+			String un_key = Base32.encode(unique_name.getBytes(Constants.UTF_8));
 
 			String	new_key = "devices.upnp.uid2." + un_key;
 

--- a/core/src/com/biglybt/core/devices/impl/DeviceTivoManager.java
+++ b/core/src/com/biglybt/core/devices/impl/DeviceTivoManager.java
@@ -171,8 +171,6 @@ DeviceTivoManager
 	encodeBeacon(
 		boolean		is_broadcast,
 		int			my_port )
-
-		throws IOException
 	{
 		String beacon =
 			"tivoconnect=1" + LF +
@@ -183,18 +181,15 @@ DeviceTivoManager
 			"platform=pc" + LF +
 			"services=TiVoMediaServer:" + my_port + "/http";
 
-		return( beacon.getBytes( "ISO-8859-1" ));
+		return beacon.getBytes(Constants.ISO_8859_1);
 	}
 
 	protected Map<String,String>
 	decodeBeacon(
 		byte[]		buffer,
 		int			length )
-
-		throws IOException
 	{
-		String str = new String( buffer, 0, length, "ISO-8859-1" );
-
+		String str = new String(buffer, 0, length, Constants.ISO_8859_1);
 		String[]	lines = str.split( LF );
 
 		Map<String,String>	map = new HashMap<>();

--- a/core/src/com/biglybt/core/disk/impl/DiskManagerImpl.java
+++ b/core/src/com/biglybt/core/disk/impl/DiskManagerImpl.java
@@ -2769,19 +2769,10 @@ DiskManagerImpl
 			  }
 	
 			  String	abs_path = move_to_dir_name.getAbsolutePath();
-	
-			  String	_average_config_key = null;
-	
-			  try{
-				  _average_config_key = "dm.move.target.abps." + Base32.encode( abs_path.getBytes( "UTF-8" ));
-	
-			  }catch( Throwable e ){
-	
-				  Debug.out(e );
-			  }
-	
-			  final String average_config_key	= _average_config_key;
-	
+
+			  final String	average_config_key = "dm.move.target.abps." +
+						Base32.encode(abs_path.getBytes(Constants.UTF_8));
+
 			  // lazy here for rare case where all non-zero length files are links
 	
 			  if ( total_bytes == 0 ){

--- a/core/src/com/biglybt/core/download/DiskManagerFileInfoFile.java
+++ b/core/src/com/biglybt/core/download/DiskManagerFileInfoFile.java
@@ -22,6 +22,7 @@ package com.biglybt.core.download;
 
 import java.io.File;
 
+import com.biglybt.core.util.Constants;
 import com.biglybt.core.util.CopyOnWriteList;
 import com.biglybt.core.util.Debug;
 import com.biglybt.core.util.QTFastStartRAF;
@@ -43,15 +44,8 @@ DiskManagerFileInfoFile
 	DiskManagerFileInfoFile(
 		File		_file )
 	{
-		file		= _file;
-
-		try{
-			hash		= new SHA1Simple().calculateHash( file.getAbsolutePath().getBytes( "UTF-8" ));
-
-		}catch( Throwable e ){
-
-			Debug.out(e);
-		}
+		file = _file;
+		hash = new SHA1Simple().calculateHash(file.getAbsolutePath().getBytes(Constants.UTF_8));
 	}
 
 	@Override

--- a/core/src/com/biglybt/core/download/DiskManagerFileInfoStream.java
+++ b/core/src/com/biglybt/core/download/DiskManagerFileInfoStream.java
@@ -54,13 +54,7 @@ DiskManagerFileInfoStream
 		stream_factory		= _stream_factory;
 		save_to				= _save_to;
 
-		try{
-			hash		= new SHA1Simple().calculateHash( _save_to.getAbsolutePath().getBytes( "UTF-8" ));
-
-		}catch( Throwable e ){
-
-			Debug.out(e);
-		}
+		hash = new SHA1Simple().calculateHash(_save_to.getAbsolutePath().getBytes(Constants.UTF_8));
 	}
 
 	public boolean

--- a/core/src/com/biglybt/core/download/DiskManagerFileInfoURL.java
+++ b/core/src/com/biglybt/core/download/DiskManagerFileInfoURL.java
@@ -95,13 +95,7 @@ DiskManagerFileInfoURL
 			}
 		}
 
-		try{
-			hash		= new SHA1Simple().calculateHash( ( "DiskManagerFileInfoURL" +  url.toExternalForm()).getBytes( "UTF-8" ));
-
-		}catch( Throwable e ){
-
-			Debug.out(e);
-		}
+		hash = new SHA1Simple().calculateHash(("DiskManagerFileInfoURL" + url.toExternalForm()).getBytes(Constants.UTF_8));
 
 		String file_name;
 

--- a/core/src/com/biglybt/core/download/impl/DownloadManagerStateImpl.java
+++ b/core/src/com/biglybt/core/download/impl/DownloadManagerStateImpl.java
@@ -4006,13 +4006,8 @@ DownloadManagerStateImpl
 
 				byte[] name = (byte[])c.get( "utf8name" );
 				if (name != null) {
-					String utf8name;
-					try {
-						utf8name = new String(name, "utf8");
-					} catch (UnsupportedEncodingException e) {
-						return null;
-					}
-					if (utf8name.length() == 0) {
+					String utf8name = new String(name, Constants.UTF_8);
+					if (utf8name.isEmpty()) {
 						return null;
 					}
 					return utf8name;
@@ -4437,15 +4432,7 @@ DownloadManagerStateImpl
 					return( null );
 				}
 
-				try{
-					return( new String( res, "UTF8" ));
-
-				}catch( Throwable e ){
-
-					Debug.printStackTrace( e );
-
-					return( null );
-				}
+				return new String( res, Constants.UTF_8);
 			}
 
 	   		if ( fixup()){

--- a/core/src/com/biglybt/core/global/impl/GlobalManagerImpl.java
+++ b/core/src/com/biglybt/core/global/impl/GlobalManagerImpl.java
@@ -27,7 +27,6 @@ package com.biglybt.core.global.impl;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.*;
@@ -2653,7 +2652,7 @@ public class GlobalManagerImpl
 					Long[] array_file_priorities = new Long[0];
 			  	for (Object key : map_file_priorities.keySet()) {
 						long priority = Long.parseLong(key.toString());
-						String indexRanges = new String((byte[]) map_file_priorities.get(key), "utf-8");
+						String indexRanges = new String((byte[]) map_file_priorities.get(key), Constants.UTF_8);
 						String[] rangesStrings = indexRanges.split(",");
 
 						if (array_file_priorities.length == 0 && rangesStrings.length > 1) {
@@ -2686,11 +2685,7 @@ public class GlobalManagerImpl
 				  return( dm );
 			  }
 		  }
-	  }
-	  catch (UnsupportedEncodingException e1) {
-		  //Do nothing and process next.
-	  }
-	  catch (Throwable e) {
+	  } catch (Throwable e) {
 		  Logger.log(new LogEvent(LOGID,
 				  "Error while loading downloads.  " +
 				  "One download may not have been added to the list.", e));

--- a/core/src/com/biglybt/core/history/impl/DownloadHistoryManagerImpl.java
+++ b/core/src/com/biglybt/core/history/impl/DownloadHistoryManagerImpl.java
@@ -770,29 +770,24 @@ DownloadHistoryManagerImpl
 
 		// System.out.println( "loading " + file );
 
-		try{
-			if ( FileUtil.resilientConfigFileExists( file )){
+		if (FileUtil.resilientConfigFileExists(file)) {
+			Map map = FileUtil.readResilientConfigFile(file);
 
-				Map map = FileUtil.readResilientConfigFile( file );
+			List<Map<String, Object>> list = (List<Map<String, Object>>) map.get("records");
+			if (list != null) {
 
-				List<Map<String,Object>>	list = (List<Map<String,Object>>)map.get( "records" );
+				for (Map<String, Object> m : list) {
 
-				for ( Map<String,Object> m: list ){
+					try {
+						DownloadHistoryImpl record = new DownloadHistoryImpl(result, m);
+						result.put(record.getUID(), record);
 
-					try{
-						DownloadHistoryImpl record = new DownloadHistoryImpl( result, m );
+					} catch (Throwable e) {
 
-						result.put( record.getUID(), record );
-
-					}catch( Throwable e ){
-
-						Debug.out( e );
+						Debug.out(e);
 					}
 				}
 			}
-		}catch( Throwable e ){
-
-			Debug.out( e );
 		}
 
 		return( result );
@@ -814,15 +809,8 @@ DownloadHistoryManagerImpl
 
 			for ( DownloadHistoryImpl record: records.values()){
 
-				try{
-					Map<String,Object>	m = record.exportToMap();
-
-					list.add( m );
-
-				}catch( Throwable e ){
-
-					Debug.out( e );
-				}
+				Map<String, Object> m = record.exportToMap();
+				list.add(m);
 			}
 
 			FileUtil.writeResilientConfigFile( file, map );
@@ -914,6 +902,9 @@ DownloadHistoryManagerImpl
 			updateCompleteTime( dms );
 		}
 
+		/**
+		 * @throws IOException when decoding fails
+		 */
 		DownloadHistoryImpl(
 			Map<Long,DownloadHistoryImpl>		_history_ref,
 			Map<String,Object>					map )
@@ -926,8 +917,8 @@ DownloadHistoryManagerImpl
 				uid		= (Long)map.get( "u" );
 				hash	= (byte[])map.get("h");
 
-				name 			= new String((byte[])map.get( "n"), "UTF-8" );
-				save_location 	= new String((byte[])map.get( "s"), "UTF-8" );
+				name = new String((byte[]) map.get("n"), Constants.UTF_8);
+				save_location = new String((byte[]) map.get("s"), Constants.UTF_8);
 
 				Long l_size		= (Long)map.get( "z" );
 
@@ -936,10 +927,6 @@ DownloadHistoryManagerImpl
 				add_time 		= (Long)map.get( "a" );
 				complete_time 	= (Long)map.get( "c" );
 				remove_time 	= (Long)map.get( "r" );
-
-			}catch( IOException e ){
-
-				throw( e );
 
 			}catch( Throwable e ){
 
@@ -954,23 +941,19 @@ DownloadHistoryManagerImpl
 			history_ref	= ref;
 		}
 
-		Map<String,Object>
-		exportToMap()
+		Map<String, Object> exportToMap() {
+			Map<String, Object> map = new LightHashMap<>();
 
-			throws IOException
-		{
-			Map<String,Object> map = new LightHashMap<>();
+			map.put("u", uid);
+			map.put("h", hash);
+			map.put("n", name.getBytes(Constants.UTF_8));
+			map.put("z", size);
+			map.put("s", save_location.getBytes(Constants.UTF_8));
+			map.put("a", add_time);
+			map.put("c", complete_time);
+			map.put("r", remove_time);
 
-			map.put( "u", uid );
-			map.put( "h", hash );
-			map.put( "n", name.getBytes( "UTF-8" ));
-			map.put( "z", size );
-			map.put( "s", save_location.getBytes( "UTF-8" ));
-			map.put( "a", add_time );
-			map.put( "c", complete_time );
-			map.put( "r", remove_time );
-
-			return( map );
+			return map;
 		}
 
 		boolean

--- a/core/src/com/biglybt/core/messenger/config/PlatformSubscriptionsMessenger.java
+++ b/core/src/com/biglybt/core/messenger/config/PlatformSubscriptionsMessenger.java
@@ -33,6 +33,7 @@ import com.biglybt.core.messenger.PlatformMessengerException;
 import com.biglybt.core.security.CryptoECCUtils;
 import com.biglybt.core.util.Base32;
 import com.biglybt.core.util.ByteFormatter;
+import com.biglybt.core.util.Constants;
 
 public class
 PlatformSubscriptionsMessenger
@@ -303,15 +304,7 @@ PlatformSubscriptionsMessenger
 
 			}else if ( obj instanceof byte[] ){
 
-				byte[]	bytes = (byte[])obj;
-
-				try{
-					return( new String( bytes, "UTF-8" ));
-
-				}catch( Throwable e ){
-
-					return( new String( bytes ));
-				}
+				return new String((byte[])obj, Constants.UTF_8);
 			}else{
 
 				return( null );

--- a/core/src/com/biglybt/core/metasearch/Engine.java
+++ b/core/src/com/biglybt/core/metasearch/Engine.java
@@ -250,20 +250,13 @@ Engine
 	getSubscription();
 
 	public Map<String,Object>
-	exportToBencodedMap()
+	exportToBencodedMap();
 
-		throws IOException;
-
-	public Map<String,Object>
-	exportToBencodedMap(
-		boolean		generic )
-
-		throws IOException;
+	public Map<String, Object>
+	exportToBencodedMap(boolean generic);
 
 	public String
-	exportToJSONString()
-
-		throws IOException;
+	exportToJSONString();
 
 	public void
 	exportToVuzeFile(

--- a/core/src/com/biglybt/core/metasearch/impl/EngineImpl.java
+++ b/core/src/com/biglybt/core/metasearch/impl/EngineImpl.java
@@ -24,11 +24,11 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.util.*;
 
-import com.biglybt.util.MapUtils;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 
@@ -49,6 +49,7 @@ import com.biglybt.core.vuzefile.VuzeFile;
 import com.biglybt.core.vuzefile.VuzeFileComponent;
 import com.biglybt.core.vuzefile.VuzeFileHandler;
 import com.biglybt.util.JSONUtils;
+import com.biglybt.util.MapUtils;
 
 
 public abstract class
@@ -275,8 +276,6 @@ EngineImpl
 	exportToBencodedMap(
 		Map			map,
 		boolean		generic )
-
-		throws IOException
 	{
 		map.put( "type", new Long( type ));
 
@@ -364,8 +363,6 @@ EngineImpl
 	protected void
 	exportToJSONObject(
 		JSONObject		res )
-
-		throws IOException
 	{
 		exportJSONMappings( res, "value_map", first_level_mapping, true );
 		exportJSONMappings( res, "ctype_map", second_level_mapping, false );
@@ -388,8 +385,6 @@ EngineImpl
 		JSONObject		map,
 		String			str,
 		boolean			level_1 )
-
-		throws IOException
 	{
 		List	result = new ArrayList();
 
@@ -428,23 +423,27 @@ EngineImpl
 
 					JSONObject mapping = (JSONObject)mappings.get(i);
 
-					String	from_str 	= URLDecoder.decode((String)mapping.get( level_1?"from_string":"cat_string" ),"UTF-8");
+					String	from_str 	= null;
+					try {
+						from_str = URLDecoder.decode((String)mapping.get( level_1?"from_string":"cat_string" ),"UTF-8");
+					} catch (UnsupportedEncodingException ignored) {
+					}
 
 					if ( from_str == null ){
 
 						log( "'from' value missing in " + mapping );
-
 						continue;
 					}
 
-					from_str 	= URLDecoder.decode( from_str, "UTF-8" );
-
-					String	to_str 		= URLDecoder.decode((String)mapping.get( level_1?"to_string":"media_type" ),"UTF-8");
+					String	to_str 		= null;
+					try {
+						to_str = URLDecoder.decode((String)mapping.get( level_1?"to_string":"media_type" ),"UTF-8");
+					} catch (UnsupportedEncodingException ignored) {
+					}
 
 					if ( to_str == null ){
 
 						log( "'to' value missing in " + mapping );
-
 						continue;
 					}
 
@@ -550,8 +549,6 @@ EngineImpl
 		Map		map,
 		String	name,
 		List	mappings )
-
-		throws IOException
 	{
 		List	l = new ArrayList();
 
@@ -591,8 +588,6 @@ EngineImpl
 	@Override
 	public String
 	exportToJSONString()
-
-		throws IOException
 	{
 		JSONObject	obj = new JSONObject();
 

--- a/core/src/com/biglybt/core/metasearch/impl/MetaSearchImpl.java
+++ b/core/src/com/biglybt/core/metasearch/impl/MetaSearchImpl.java
@@ -1269,16 +1269,8 @@ MetaSearchImpl
 
 		for ( Engine engine: engines ){
 
-			try{
-				vf.addComponent(
-					VuzeFileComponent.COMP_TYPE_METASEARCH_TEMPLATE,
+			vf.addComponent(VuzeFileComponent.COMP_TYPE_METASEARCH_TEMPLATE,
 					engine.exportToBencodedMap());
-
-			}catch( IOException e ){
-
-				Debug.out( e );
-			}
-
 		}
 
 		try{

--- a/core/src/com/biglybt/core/metasearch/impl/plugin/PluginEngine.java
+++ b/core/src/com/biglybt/core/metasearch/impl/plugin/PluginEngine.java
@@ -117,8 +117,6 @@ PluginEngine
 	@Override
 	public Map
 	exportToBencodedMap()
-
-		throws IOException
 	{
 		return( exportToBencodedMap( false ));
 	}
@@ -127,8 +125,6 @@ PluginEngine
 	public Map
 	exportToBencodedMap(
 		boolean	generic )
-
-		throws IOException
 	{
 		Map	res = new HashMap();
 

--- a/core/src/com/biglybt/core/metasearch/impl/web/WebEngine.java
+++ b/core/src/com/biglybt/core/metasearch/impl/web/WebEngine.java
@@ -26,7 +26,6 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.biglybt.util.MapUtils;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 
@@ -50,6 +49,7 @@ import com.biglybt.pif.utils.StaticUtilities;
 import com.biglybt.pif.utils.resourcedownloader.ResourceDownloader;
 import com.biglybt.pif.utils.resourcedownloader.ResourceDownloaderException;
 import com.biglybt.pif.utils.resourcedownloader.ResourceDownloaderFactory;
+import com.biglybt.util.MapUtils;
 import com.biglybt.util.UrlFilter;
 
 public abstract class
@@ -180,8 +180,6 @@ WebEngine
 	exportToBencodedMap(
 		Map		map,
 		boolean	generic )
-
-		throws IOException
 	{
 		super.exportToBencodedMap( map, generic );
 
@@ -346,8 +344,6 @@ WebEngine
 	protected void
 	exportToJSONObject(
 		JSONObject		res )
-
-		throws IOException
 	{
 		super.exportToJSONObject( res );
 

--- a/core/src/com/biglybt/core/metasearch/impl/web/json/JSONEngine.java
+++ b/core/src/com/biglybt/core/metasearch/impl/web/json/JSONEngine.java
@@ -24,7 +24,6 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.biglybt.util.MapUtils;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
@@ -38,6 +37,7 @@ import com.biglybt.core.metasearch.impl.web.WebResult;
 import com.biglybt.core.util.ByteFormatter;
 import com.biglybt.core.util.Debug;
 import com.biglybt.core.util.UrlUtils;
+import com.biglybt.util.MapUtils;
 
 public class
 JSONEngine
@@ -158,8 +158,6 @@ JSONEngine
 	@Override
 	public Map
 	exportToBencodedMap()
-
-		throws IOException
 	{
 		return( exportToBencodedMap( false ));
 	}
@@ -168,8 +166,6 @@ JSONEngine
 	public Map
 	exportToBencodedMap(
 		boolean		generic )
-
-		throws IOException
 	{
 		Map	res = new HashMap();
 
@@ -186,8 +182,6 @@ JSONEngine
 	protected void
 	exportToJSONObject(
 		JSONObject		res )
-
-		throws IOException
 	{
 		res.put( "json_result_key", resultsEntryPath );
 

--- a/core/src/com/biglybt/core/metasearch/impl/web/regex/RegexEngine.java
+++ b/core/src/com/biglybt/core/metasearch/impl/web/regex/RegexEngine.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.biglybt.util.MapUtils;
 import org.json.simple.JSONObject;
 
 import com.biglybt.core.metasearch.*;
@@ -41,6 +40,7 @@ import com.biglybt.core.util.ByteFormatter;
 import com.biglybt.core.util.Debug;
 import com.biglybt.core.util.TimeLimitedTask;
 import com.biglybt.core.util.UrlUtils;
+import com.biglybt.util.MapUtils;
 
 public class
 RegexEngine
@@ -162,8 +162,6 @@ RegexEngine
 	@Override
 	public Map
 	exportToBencodedMap()
-
-		throws IOException
 	{
 		return( exportToBencodedMap( false ));
 	}
@@ -172,8 +170,6 @@ RegexEngine
 	public Map
 	exportToBencodedMap(
 		boolean		generic )
-
-		throws IOException
 	{
 		Map	res = new HashMap();
 
@@ -188,8 +184,6 @@ RegexEngine
 	protected void
 	exportToJSONObject(
 		JSONObject		res )
-
-		throws IOException
 	{
 		res.put( "regexp", UrlUtils.encode( pattern_str ));
 

--- a/core/src/com/biglybt/core/metasearch/impl/web/rss/RSSEngine.java
+++ b/core/src/com/biglybt/core/metasearch/impl/web/rss/RSSEngine.java
@@ -137,8 +137,6 @@ RSSEngine
 	@Override
 	public Map
 	exportToBencodedMap()
-
-		throws IOException
 	{
 		return( exportToBencodedMap( false ));
 	}
@@ -147,8 +145,6 @@ RSSEngine
 	public Map
 	exportToBencodedMap(
 		boolean	generic )
-
-		throws IOException
 	{
 		Map	res = new HashMap();
 

--- a/core/src/com/biglybt/core/networkmanager/admin/impl/NetworkAdminImpl.java
+++ b/core/src/com/biglybt/core/networkmanager/admin/impl/NetworkAdminImpl.java
@@ -3619,20 +3619,13 @@ addressLoop:
 		}.start();
 	}
 
-	private String
-	getConfigKey(
-		NetworkInterface	intf )
-	{
-		try{
-			return( Base32.encode( intf.getName().getBytes( "UTF-8" )));
-
-		}catch( Throwable e ){
-
-			Debug.out( e );
-
-			return( "derp" );
+	private String getConfigKey(NetworkInterface intf) {
+		if (intf.getName() != null) {
+			return Base32.encode(intf.getName().getBytes(Constants.UTF_8));
 		}
+		return "derp";
 	}
+
 	private int
 	categoriseIntf(
 		NetworkInterface	intf )

--- a/core/src/com/biglybt/core/networkmanager/impl/http/HTTPNetworkManager.java
+++ b/core/src/com/biglybt/core/networkmanager/impl/http/HTTPNetworkManager.java
@@ -19,7 +19,6 @@
 
 package com.biglybt.core.networkmanager.impl.http;
 
-import java.io.UnsupportedEncodingException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URLDecoder;
@@ -46,6 +45,7 @@ import com.biglybt.core.stats.CoreStats;
 import com.biglybt.core.stats.CoreStatsProvider;
 import com.biglybt.core.torrent.TOTorrentFile;
 import com.biglybt.core.util.BEncoder;
+import com.biglybt.core.util.Constants;
 import com.biglybt.core.util.CopyOnWriteList;
 import com.biglybt.core.util.Debug;
 
@@ -704,13 +704,7 @@ HTTPNetworkManager
 	{
 		byte[]	bytes;
 
-		try{
-			bytes = data.getBytes( "ISO-8859-1" );
-
-		}catch( UnsupportedEncodingException e ){
-
-			bytes = data.getBytes();
-		}
+		bytes = data.getBytes(Constants.ISO_8859_1);
 
 		final ByteBuffer bb = ByteBuffer.wrap( bytes );
 

--- a/core/src/com/biglybt/core/pairing/impl/PairingManagerImpl.java
+++ b/core/src/com/biglybt/core/pairing/impl/PairingManagerImpl.java
@@ -475,14 +475,8 @@ PairingManagerImpl
 				byte[] b_ps = (byte[])vc_data.get( "pairing_server" );
 		
 				if ( b_ps != null ){
-						
-					try{
-						String ps = new String( b_ps, "UTF-8" );
-							
-						_SERVICE_URL = ps;
-						
-					}catch( Throwable e ){
-					}
+
+					_SERVICE_URL = new String(b_ps, Constants.UTF_8);
 				}else{
 					
 					_SERVICE_URL = DEFAULT_SERVICE_URL;
@@ -493,14 +487,8 @@ PairingManagerImpl
 				byte[] b_ts = (byte[])vc_data.get( "tunnel_server" );
 				
 				if ( b_ts != null ){
-					
-					try{
-						String ts = new String( b_ts, "UTF-8" );
-						
-						_TUNNEL_SERVER = ts;
-						
-					}catch( Throwable e ){
-					}
+
+					_TUNNEL_SERVER = new String(b_ts, Constants.UTF_8);
 				}else{
 					
 					_TUNNEL_SERVER = DEFAULT_TUNNEL_SERVER;
@@ -511,13 +499,12 @@ PairingManagerImpl
 				byte[] b_wr = (byte[])vc_data.get( "web_remote_server" );
 		
 				if ( b_wr != null ){
-					
+
+					String wr = new String( b_wr, Constants.UTF_8);
+
 					try{
-						String wr = new String( b_wr, "UTF-8" );
-						
 						_WEB_REMOTE_URL = new URL( wr );
-						
-					}catch( Throwable e ){
+					}catch(MalformedURLException ignored ){
 					}
 				}else{
 					

--- a/core/src/com/biglybt/core/pairing/impl/PairingManagerImpl.java
+++ b/core/src/com/biglybt/core/pairing/impl/PairingManagerImpl.java
@@ -2052,8 +2052,6 @@ PairingManagerImpl
 	getString(
 		Map<String,Object>	map,
 		String				name )
-
-		throws IOException
 	{
 		byte[]	bytes = (byte[])map.get(name);
 
@@ -2062,7 +2060,7 @@ PairingManagerImpl
 			return( null );
 		}
 
-		return( new String( bytes, "UTF-8" ));
+		return new String( bytes, Constants.UTF_8);
 	}
 
 	@Override

--- a/core/src/com/biglybt/core/peermanager/peerdb/PeerItem.java
+++ b/core/src/com/biglybt/core/peermanager/peerdb/PeerItem.java
@@ -19,7 +19,6 @@
 
 package com.biglybt.core.peermanager.peerdb;
 
-import java.io.UnsupportedEncodingException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
@@ -27,6 +26,7 @@ import java.util.Arrays;
 import com.biglybt.core.peer.PEPeerSource;
 import com.biglybt.core.peer.util.PeerUtils;
 import com.biglybt.core.util.AENetworkClassifier;
+import com.biglybt.core.util.Constants;
 import com.biglybt.pif.peers.PeerDescriptor;
 
 
@@ -51,23 +51,18 @@ public class PeerItem implements PeerDescriptor {
   protected PeerItem( String _address, int _tcp_port, byte _source, byte _handshake, int _udp_port, byte _crypto_level, int _up_speed  ) {
     byte[] raw;
     network = AENetworkClassifier.categoriseAddress( _address );
-    try{
-	    if ( network == AENetworkClassifier.AT_PUBLIC ){
-		    try{
-		      //see if we can resolve the address into a compact raw IPv4/6 byte array (4 or 16 bytes)
-		      InetAddress ip = InetAddress.getByName( _address );
-		      raw = ip.getAddress();
-		    }
-		    catch( UnknownHostException e ) {
-		      //not a standard IPv4/6 address, so just use the full string bytes
-		      raw = _address.getBytes( "ISO8859-1" );
-		    }
-	    }else{
-	    	raw = _address.getBytes( "ISO8859-1" );
-	    }
-    }catch( UnsupportedEncodingException e ){
-    	raw = _address.getBytes();
-    }
+	  if (network == AENetworkClassifier.AT_PUBLIC) {
+		  try {
+			  //see if we can resolve the address into a compact raw IPv4/6 byte array (4 or 16 bytes)
+			  InetAddress ip = InetAddress.getByName(_address);
+			  raw = ip.getAddress();
+		  } catch (UnknownHostException e) {
+			  //not a standard IPv4/6 address, so just use the full string bytes
+			  raw = _address.getBytes(Constants.ISO_8859_1);
+		  }
+	  } else {
+		  raw = _address.getBytes(Constants.ISO_8859_1);
+	  }
 
     address = raw;
     tcp_port = (short)_tcp_port;
@@ -119,22 +114,17 @@ public class PeerItem implements PeerDescriptor {
 
 
   public String getAddressString() {
-	try{
-		if ( network == AENetworkClassifier.AT_PUBLIC ){
-		    try{
-		      //see if it's an IPv4/6 address (4 or 16 bytes)
-		      return InetAddress.getByAddress( address ).getHostAddress();
-		    }
-		    catch( UnknownHostException e ) {
-		      //not a standard IPv4/6 address, so just return as full string
-		      return new String( address, "ISO8859-1" );
-		    }
-		}else{
-			 return new String( address, "ISO8859-1" );
-		}
-	}catch( UnsupportedEncodingException e ){
-		return( new String( address ));
-	}
+	  if (network == AENetworkClassifier.AT_PUBLIC) {
+		  try {
+			  //see if it's an IPv4/6 address (4 or 16 bytes)
+			  return InetAddress.getByAddress(address).getHostAddress();
+		  } catch (UnknownHostException e) {
+			  //not a standard IPv4/6 address, so just return as full string
+			  return new String(address, Constants.ISO_8859_1);
+		  }
+	  } else {
+		  return new String(address, Constants.ISO_8859_1);
+	  }
   }
 
   @Override

--- a/core/src/com/biglybt/core/speedmanager/SpeedLimitHandler.java
+++ b/core/src/com/biglybt/core/speedmanager/SpeedLimitHandler.java
@@ -3629,11 +3629,7 @@ SpeedLimitHandler
     	String				key,
     	String				s )
     {
-    	try{
-    		map.put( key, s.getBytes( "UTF-8" ));
-
-    	}catch( Throwable e ){
-    	}
+	    map.put(key, s.getBytes(Constants.UTF_8));
     }
 
     private String
@@ -3649,12 +3645,8 @@ SpeedLimitHandler
 
        	}else if ( obj instanceof byte[] ){
 
-    		try{
-    			return( new String((byte[])obj, "UTF-8" ));
-
-    		}catch( Throwable e ){
-	    	}
-       	}
+	        return new String((byte[]) obj, Constants.UTF_8);
+        }
 
     	return( null );
     }

--- a/core/src/com/biglybt/core/subs/impl/SubscriptionImpl.java
+++ b/core/src/com/biglybt/core/subs/impl/SubscriptionImpl.java
@@ -21,12 +21,10 @@
 package com.biglybt.core.subs.impl;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.URL;
 import java.security.KeyPair;
 import java.util.*;
 
-import com.biglybt.util.MapUtils;
 import org.gudy.bouncycastle.util.encoders.Base64;
 import org.json.simple.JSONObject;
 
@@ -48,6 +46,7 @@ import com.biglybt.core.util.DataSourceResolver.ExportedDataSource;
 import com.biglybt.core.vuzefile.VuzeFile;
 import com.biglybt.core.vuzefile.VuzeFileHandler;
 import com.biglybt.util.JSONUtils;
+import com.biglybt.util.MapUtils;
 
 public class
 SubscriptionImpl
@@ -299,8 +298,6 @@ SubscriptionImpl
 	SubscriptionImpl(
 		SubscriptionManagerImpl		_manager,
 		Map							map )
-
-		throws IOException
 	{
 		manager	= _manager;
 
@@ -378,16 +375,12 @@ SubscriptionImpl
 		sig_data_size	= body.getSigDataSize();
 	}
 
-	protected Map
-	toMap()
-
-		throws IOException
-	{
+	protected Map toMap() {
 		synchronized( this ){
 
 			Map	map = new HashMap();
 
-			map.put( "name", name.getBytes( "UTF-8" ));
+			map.put( "name", name.getBytes(Constants.UTF_8));
 
 			map.put( "public_key", public_key );
 
@@ -459,12 +452,12 @@ SubscriptionImpl
 
 			if ( creator_ref != null ){
 
-				map.put( "cref", creator_ref.getBytes( "UTF-8" ));
+				map.put( "cref", creator_ref.getBytes(Constants.UTF_8));
 			}
 
 			if ( category != null ){
 
-				map.put( "cat", category.getBytes( "UTF-8" ));
+				map.put( "cat", category.getBytes(Constants.UTF_8));
 			}
 
 			if ( tag_id != -1 ){
@@ -479,20 +472,16 @@ SubscriptionImpl
 
 			if ( parent != null ){
 
-				map.put( "par", parent.getBytes( "UTF-8" ));
+				map.put( "par", parent.getBytes(Constants.UTF_8));
 			}
 
 			return( map );
 		}
 	}
 
-	protected void
-	fromMap(
-		Map		map )
+	protected void fromMap(Map map) {
 
-		throws IOException
-	{
-		name				= new String((byte[])map.get( "name"), "UTF-8" );
+		name				= new String((byte[])map.get( "name"), Constants.UTF_8);
 		public_key			= (byte[])map.get( "public_key" );
 		private_key			= (byte[])map.get( "private_key" );
 		version				= ((Long)map.get( "version" )).intValue();
@@ -529,8 +518,7 @@ SubscriptionImpl
 		byte[]	b_local_name = (byte[])map.get( "local_name" );
 
 		if ( b_local_name != null ){
-
-			local_name = new String( b_local_name, "UTF-8" );
+			local_name = new String( b_local_name, Constants.UTF_8);
 		}
 
 		List	l_assoc = (List)map.get( "assoc" );
@@ -558,15 +546,13 @@ SubscriptionImpl
 		byte[] b_cref = (byte[])map.get( "cref" );
 
 		if ( b_cref != null ){
-
-			creator_ref = new String( b_cref, "UTF-8" );
+			creator_ref = new String( b_cref, Constants.UTF_8);
 		}
 
 		byte[] b_cat = (byte[])map.get( "cat" );
 
 		if ( b_cat != null ){
-
-			category = new String( b_cat, "UTF-8" );
+			category = new String( b_cat, Constants.UTF_8);
 		}
 
 		Long l_tag_id = (Long)map.get( "tag" );
@@ -586,8 +572,7 @@ SubscriptionImpl
 		byte[] b_parent = (byte[])map.get( "par" );
 
 		if ( b_parent != null ){
-
-			parent = new String( b_parent, "UTF-8" );
+			parent = new String( b_parent, Constants.UTF_8);
 		}
 	}
 

--- a/core/src/com/biglybt/core/subs/impl/SubscriptionManagerImpl.java
+++ b/core/src/com/biglybt/core/subs/impl/SubscriptionManagerImpl.java
@@ -30,7 +30,6 @@ import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
-import com.biglybt.util.MapUtils;
 import org.gudy.bouncycastle.util.encoders.Base64;
 
 import com.biglybt.core.Core;
@@ -92,6 +91,7 @@ import com.biglybt.plugin.net.buddy.BuddyPluginBeta;
 import com.biglybt.plugin.net.buddy.BuddyPluginBeta.ChatInstance;
 import com.biglybt.plugin.net.buddy.BuddyPluginBeta.ChatMessage;
 import com.biglybt.plugin.net.buddy.BuddyPluginUtils;
+import com.biglybt.util.MapUtils;
 import com.biglybt.util.UrlFilter;
 
 
@@ -7789,20 +7789,10 @@ SubscriptionManagerImpl
 		}
 	}
 
-	private byte[]
-	getKeyBytes(
-		String		key )
-	{
-		try{
-			return( key.getBytes( "UTF-8" ));
-
-		}catch( UnsupportedEncodingException e ){
-
-			Debug.out( e );
-
-			return( key.getBytes());
-		}
+	private byte[] getKeyBytes(String key) {
+		return key.getBytes(Constants.UTF_8);
 	}
+
 	private AEDiagnosticsLogger
 	getLogger()
 	{

--- a/core/src/com/biglybt/core/subs/impl/SubscriptionResultImpl.java
+++ b/core/src/com/biglybt/core/subs/impl/SubscriptionResultImpl.java
@@ -77,17 +77,11 @@ SubscriptionResultImpl
 
 		String	key1_str =  result.getEngine().getId() + ":" + result.getName();
 
-		try{
-			byte[] sha1 = new SHA1Simple().calculateHash( key1_str.getBytes( "UTF-8" ));
+		byte[] key1_sha = new SHA1Simple().calculateHash(key1_str.getBytes(Constants.UTF_8));
 
-			key1 = new byte[10];
+		key1 = new byte[10];
 
-			System.arraycopy( sha1, 0, key1, 0, 10 );
-
-		}catch( Throwable e ){
-
-			Debug.printStackTrace(e);
-		}
+		System.arraycopy(key1_sha, 0, key1, 0, 10);
 
 		String	uid = result.getUID();
 
@@ -95,17 +89,11 @@ SubscriptionResultImpl
 
 			String	key2_str = result.getEngine().getId() + ":" + uid;
 
-			try{
-				byte[] sha1 = new SHA1Simple().calculateHash( key2_str.getBytes( "UTF-8" ));
+			byte[] key2_sha = new SHA1Simple().calculateHash(key2_str.getBytes(Constants.UTF_8));
 
-				key2 = new byte[10];
+			key2 = new byte[10];
 
-				System.arraycopy( sha1, 0, key2, 0, 10 );
-
-			}catch( Throwable e ){
-
-				Debug.printStackTrace(e);
-			}
+			System.arraycopy(key2_sha, 0, key2, 0, 10);
 		}
 	}
 
@@ -129,12 +117,9 @@ SubscriptionResultImpl
 
 		}else{
 
-			try{
-				result_json	= new String((byte[])map.get( "result_json" ), "UTF-8" );
-
-			}catch( Throwable e ){
-
-				Debug.printStackTrace(e);
+			Object result_json_bytes = map.get("result_json");
+			if (result_json_bytes != null) {
+				result_json = new String((byte[]) result_json_bytes, Constants.UTF_8);
 			}
 		}
 	}
@@ -279,12 +264,8 @@ SubscriptionResultImpl
 
 		}else{
 
-			try{
-				map.put( "result_json", result_json.getBytes( "UTF-8" ));
-
-			}catch( Throwable e ){
-
-				Debug.printStackTrace(e);
+			if (result_json != null) {
+				map.put("result_json", result_json.getBytes(Constants.UTF_8));
 			}
 		}
 

--- a/core/src/com/biglybt/core/torrent/impl/TOTorrentFileImpl.java
+++ b/core/src/com/biglybt/core/torrent/impl/TOTorrentFileImpl.java
@@ -274,13 +274,7 @@ TOTorrentFileImpl
 			for (int j = 0; j < pathComponentsUTF8.length; j++) {
 
 				try {
-					String comp;
-					try {
-						comp =  new String(pathComponentsUTF8[j], "utf8");
-					} catch (UnsupportedEncodingException e) {
-						System.out.println("file - unsupported encoding!!!!");
-						comp = "UnsupportedEncoding";
-					}
+					String comp = new String(pathComponentsUTF8[j], Constants.UTF_8);
 
 					comp = FileUtil.convertOSSpecificChars(comp, j != pathComponentsUTF8.length-1 );
 

--- a/core/src/com/biglybt/core/torrent/impl/TOTorrentImpl.java
+++ b/core/src/com/biglybt/core/torrent/impl/TOTorrentImpl.java
@@ -508,12 +508,7 @@ TOTorrentImpl
 	public String
 	getUTF8Name()
 	{
-		try {
-			return torrent_name_utf8 == null ? null : new String(torrent_name_utf8,
-					"utf8");
-		} catch (UnsupportedEncodingException e) {
-			return null;
-		}
+		return torrent_name_utf8 == null ? null : new String(torrent_name_utf8, Constants.UTF_8);
 	}
 
 	protected void

--- a/core/src/com/biglybt/core/util/BEncoder.java
+++ b/core/src/com/biglybt/core/util/BEncoder.java
@@ -486,45 +486,39 @@ BEncoder
        		o = String.valueOf((Double)o);
 	    } else if ( o instanceof BEncodableObject ) {
     		o = ((BEncodableObject) o).toBencodeObject();
-       	}else if ( o instanceof byte[] ){
-       		try{
-       			byte[] b = (byte[])o;
 
-       			String s = new String(b,"UTF-8");
+			} else if (o instanceof byte[]) {
+				byte[] b = (byte[]) o;
 
-       			byte[] temp = s.getBytes( "UTF-8" );
+				String s = new String(b, Constants.UTF_8);
+				byte[] temp = s.getBytes(Constants.UTF_8);
 
-       				// if converting the raw byte array into a UTF string and back again doesn't result in
-       				// the same bytes then things ain't gonna work dump as a demarked hex string that
-       				// can be recognized and handled in BDecoder appropriately
+				// if converting the raw byte array into a UTF string and back again doesn't result in
+				// the same bytes then things ain't gonna work dump as a demarked hex string that
+				// can be recognized and handled in BDecoder appropriately
 
-       			if ( !Arrays.equals( b, temp )){
-
-       				StringBuilder sb = new StringBuilder( b.length * 2 + 4 );
+				if (!Arrays.equals(b, temp)) {
+					StringBuilder sb = new StringBuilder(b.length * 2 + 4);
 
 					sb.append("\\x");
 
-       				for ( byte x: b ){
-       					String ss=Integer.toHexString(x&0xff);
-    					for(int k=0;k<2-ss.length();k++){
-    						sb.append('0');
-    					}
-    					sb.append(ss);
-       				}
-
+					for (byte x : b) {
+						String ss = Integer.toHexString(x & 0xff);
+						for (int k = 0; k < 2 - ss.length(); k++) {
+							sb.append('0');
+						}
+						sb.append(ss);
+					}
 					sb.append("\\x");
 
-       				o = sb.toString();
+					o = sb.toString();
 
-       			}else{
+				} else {
+					o = s;
+				}
+			}
 
-       				o = s;
-       			}
-       		}catch( Throwable e ){
-       		}
-       	}
-
-    	return( o );
+			return o;
     }
 
     public static boolean isEncodable(Object toCheck) {

--- a/core/src/com/biglybt/core/util/TorrentUtils.java
+++ b/core/src/com/biglybt/core/util/TorrentUtils.java
@@ -1907,24 +1907,17 @@ TorrentUtils
 	{
 		Map	m = getAzureusPrivateProperties( torrent );
 
-		try{
-			str = str.trim();
 
-			if ( str == null || str.length() == 0 ){
+		if (str == null || str.trim().isEmpty()) {
 
-				m.remove( TORRENT_AZ_PROP_OBTAINED_FROM );
+			m.remove(TORRENT_AZ_PROP_OBTAINED_FROM);
 
-			}else{
+		} else {
 
-				m.put( TORRENT_AZ_PROP_OBTAINED_FROM, str.getBytes( "UTF-8" ));
-			}
-
-			fireAttributeListener( torrent, TORRENT_AZ_PROP_OBTAINED_FROM, str );
-
-		}catch( Throwable e ){
-
-			Debug.printStackTrace(e);
+			m.put(TORRENT_AZ_PROP_OBTAINED_FROM, str.getBytes(Constants.UTF_8));
 		}
+
+		fireAttributeListener(torrent, TORRENT_AZ_PROP_OBTAINED_FROM, str);
 	}
 
 	public static String
@@ -1937,13 +1930,7 @@ TorrentUtils
 
 		if ( from != null ){
 
-			try{
-				return( new String( from, "UTF-8" ));
-
-			}catch( Throwable e ){
-
-				Debug.printStackTrace(e);
-			}
+			return new String(from, Constants.UTF_8);
 		}
 
 		return( null );
@@ -1973,36 +1960,31 @@ TorrentUtils
 
 		Map	m = getAzureusPrivateProperties( torrent );
 
-		try{
-			List l = (List)m.get( TORRENT_AZ_PROP_NETWORK_CACHE );
+		List l = (List) m.get(TORRENT_AZ_PROP_NETWORK_CACHE);
 
-			if ( l != null ){
+		if (l != null) {
 
-				for (Object o: l ){
+			for (Object o : l) {
 
-					if ( o instanceof String ){
+				if (o instanceof String) {
 
-						result.add((String)o);
+					result.add((String) o);
 
-					}else if ( o instanceof byte[] ){
+				} else if (o instanceof byte[]) {
 
-						String s = new String((byte[])o, "UTF-8" );
+					String s = new String((byte[]) o, Constants.UTF_8);
 
-						for ( String x: AENetworkClassifier.AT_NETWORKS ){
+					for (String x : AENetworkClassifier.AT_NETWORKS) {
 
-							if ( s.equals( x )){
+						if (s.equals(x)) {
 
-								result.add( x );
+							result.add(x);
 
-								break;
-							}
+							break;
 						}
 					}
 				}
 			}
-		}catch( Throwable e ){
-
-			Debug.printStackTrace(e);
 		}
 
 		return( result );
@@ -2032,28 +2014,23 @@ TorrentUtils
 
 		Map	m = getAzureusPrivateProperties( torrent );
 
-		try{
-			List l = (List)m.get( TORRENT_AZ_PROP_TAG_CACHE );
+		List l = (List) m.get(TORRENT_AZ_PROP_TAG_CACHE);
 
-			if ( l != null ){
+		if (l != null) {
 
-				for (Object o: l ){
+			for (Object o : l) {
 
-					if ( o instanceof String ){
+				if (o instanceof String) {
 
-						result.add((String)o);
+					result.add((String) o);
 
-					}else if ( o instanceof byte[] ){
+				} else if (o instanceof byte[]) {
 
-						String s = new String((byte[])o, "UTF-8" );
+					String s = new String((byte[]) o, Constants.UTF_8);
 
-						result.add( s );
-					}
+					result.add(s);
 				}
 			}
-		}catch( Throwable e ){
-
-			Debug.printStackTrace(e);
 		}
 
 		return( result );
@@ -2083,28 +2060,23 @@ TorrentUtils
 
 		Map	m = getAzureusPrivateProperties( torrent );
 
-		try{
-			List l = (List)m.get( TORRENT_AZ_PROP_INITIAL_TAGS );
+		List l = (List) m.get(TORRENT_AZ_PROP_INITIAL_TAGS);
 
-			if ( l != null ){
+		if (l != null) {
 
-				for (Object o: l ){
+			for (Object o : l) {
 
-					if ( o instanceof String ){
+				if (o instanceof String) {
 
-						result.add((String)o);
+					result.add((String) o);
 
-					}else if ( o instanceof byte[] ){
+				} else if (o instanceof byte[]) {
 
-						String s = new String((byte[])o, "UTF-8" );
+					String s = new String((byte[]) o, Constants.UTF_8);
 
-						result.add( s );
-					}
+					result.add(s);
 				}
 			}
-		}catch( Throwable e ){
-
-			Debug.printStackTrace(e);
 		}
 
 		return( result );
@@ -4480,17 +4452,7 @@ TorrentUtils
 
 		if ( is_new ){
 
-			String _config_key = "";
-
-			try{
-				_config_key = "dns.txts.cache." + Base32.encode( host.getBytes( "UTF-8" ));
-
-			}catch( Throwable e ){
-
-				Debug.out( e );
-			}
-
-			final String config_key	= _config_key;
+			final String config_key = "dns.txts.cache." + Base32.encode(host.getBytes(Constants.UTF_8));
 
 			if ( TRACE_DNS ){
 				System.out.println( "Updating DNS records for " + host );
@@ -4606,41 +4568,36 @@ TorrentUtils
 						txts = (List<String>)result[1];
 					}
 
-					try{
-						if ( txts == null ){
+					if (txts == null) {
 
-							txts = new ArrayList<>();
+						txts = new ArrayList<>();
 
-							if ( txts_cache == null ){
+						if (txts_cache == null) {
 
-								if ( TRACE_DNS ){
-									System.out.println( "    No cache" );
-								}
-							}else{
-
-								for ( Object o: txts_cache ){
-
-									txts.add( new String((byte[])o, "UTF-8" ));
-								}
-
-								if ( TRACE_DNS ){
-									System.out.println( "    Using cache: " + txts );
-								}
+							if (TRACE_DNS) {
+								System.out.println("    No cache");
 							}
-						}else{
+						} else {
 
-							txts_cache = new ArrayList();
+							for (Object o : txts_cache) {
 
-							for ( String str: txts ){
-
-								txts_cache.add( str.getBytes( "UTF-8" ));
+								txts.add(new String((byte[]) o, Constants.UTF_8));
 							}
 
-							COConfigurationManager.setParameter( config_key, txts_cache );
+							if (TRACE_DNS) {
+								System.out.println("    Using cache: " + txts);
+							}
 						}
-					}catch( Throwable e ){
+					} else {
 
-						Debug.out( e );
+						txts_cache = new ArrayList(txts.size());
+
+						for (String str : txts) {
+
+							txts_cache.add(str.getBytes(Constants.UTF_8));
+						}
+
+						COConfigurationManager.setParameter(config_key, txts_cache);
 					}
 				}
 

--- a/core/src/com/biglybt/core/util/UrlUtils.java
+++ b/core/src/com/biglybt/core/util/UrlUtils.java
@@ -837,24 +837,21 @@ public class UrlUtils
 			byte[] decode = Base64.decode(base64);
 			if (decode != null && decode.length > 0) {
 				// Format is AA/<name>/<size>/<hash>/ZZ
-				try {
-					String decodeString = new String(decode, "utf8");
-					pattern = Pattern.compile("AA.*/(.*)/ZZ", Pattern.CASE_INSENSITIVE);
-					matcher = pattern.matcher(decodeString);
-					if (matcher.find()) {
-						String hash = matcher.group(1);
-						String magnet = parseTextForMagnets(hash);
-						if (magnet != null) {
-							pattern = Pattern.compile("AA/(.*)/[0-9]+", Pattern.CASE_INSENSITIVE);
-							matcher = pattern.matcher(decodeString);
-							if (matcher.find()) {
-								String name = matcher.group(1);
-								return magnet + "&dn=" + encode(name);
-							}
-							return magnet;
+				String decodeString = new String(decode, Constants.UTF_8);
+				pattern = Pattern.compile("AA.*/(.*)/ZZ", Pattern.CASE_INSENSITIVE);
+				matcher = pattern.matcher(decodeString);
+				if (matcher.find()) {
+					String hash = matcher.group(1);
+					String magnet = parseTextForMagnets(hash);
+					if (magnet != null) {
+						pattern = Pattern.compile("AA/(.*)/[0-9]+", Pattern.CASE_INSENSITIVE);
+						matcher = pattern.matcher(decodeString);
+						if (matcher.find()) {
+							String name = matcher.group(1);
+							return magnet + "&dn=" + encode(name);
 						}
+						return magnet;
 					}
-				} catch (UnsupportedEncodingException e) {
 				}
 			}
 		}
@@ -1252,38 +1249,31 @@ public class UrlUtils
 	{
 		String	headers_to_use = getBrowserHeadersToUse( null );
 
-		Map	result = new HashMap();
+		Map<String, String>	result = new HashMap<>();
 
-		try{
+		String header_string = new String(Base64.decode(headers_to_use), Constants.UTF_8);
 
-			String header_string = new String( Base64.decode( headers_to_use ), "UTF-8" );
+		String[] headers = header_string.split("\n");
 
-			String[]	headers = header_string.split( "\n" );
+		for (String header : headers) {
 
-			for (int i=0;i<headers.length;i++ ){
+			int pos = header.indexOf(':');
 
-				String	header = headers[i];
+			if (pos != -1) {
 
-				int	pos = header.indexOf( ':' );
+				String lhs = header.substring(0, pos).trim();
+				String rhs = header.substring(pos + 1).trim();
 
-				if ( pos != -1 ){
+				if (!(lhs.equalsIgnoreCase("Host") || lhs.equalsIgnoreCase("Referer"))) {
 
-					String	lhs = header.substring(0,pos).trim();
-					String	rhs	= header.substring(pos+1).trim();
-
-					if ( !( lhs.equalsIgnoreCase( "Host") ||
-							lhs.equalsIgnoreCase( "Referer" ))){
-
-						result.put( lhs, rhs );
-					}
+					result.put(lhs, rhs);
 				}
 			}
+		}
 
-			if ( referer != null && referer.length() > 0){
+		if (referer != null && referer.length() > 0) {
 
-				result.put( "Referer", referer );
-			}
-		}catch( Throwable e ){
+			result.put("Referer", referer);
 		}
 
 		return( result );

--- a/core/src/com/biglybt/core/xml/util/XUXmlWriter.java
+++ b/core/src/com/biglybt/core/xml/util/XUXmlWriter.java
@@ -382,13 +382,7 @@ XUXmlWriter
 	{
 		if ( generic_simple ){
 
-			try{
-				writeLineRaw( escapeXML( new String(bytes, "UTF-8" )));
-
-			}catch( Throwable e ){
-
-				e.printStackTrace();
-			}
+			writeLineRaw(escapeXML(new String(bytes, Constants.UTF_8)));
 		}else{
 
 			writeTag( "BYTES", encodeBytes( bytes ));

--- a/core/src/com/biglybt/pifimpl/local/clientid/ClientIDPlugin.java
+++ b/core/src/com/biglybt/pifimpl/local/clientid/ClientIDPlugin.java
@@ -36,7 +36,6 @@ import com.biglybt.pif.PluginInterface;
 import com.biglybt.pif.PluginManager;
 import com.biglybt.pif.clientid.ClientIDGenerator;
 import com.biglybt.pif.ui.config.*;
-
 import com.biglybt.pif.ui.model.BasicPluginConfigModel;
 
 /**
@@ -172,15 +171,11 @@ ClientIDPlugin
 				id[6]	= (byte)ML_BIGLY_VERSION.charAt( ML_BIGLY_VERSION.length()-1 );
 			}
 		}else{
-			
-			try{
-				byte[] b_prefix = "-AZ5750".getBytes( "ISO-8859-1" );
-			
-				for ( int i=0;i<b_prefix.length;i++){
-					
-					id[i] = b_prefix[i];
-				}
-			}catch( Throwable e ){
+
+			byte[] b_prefix = "-AZ5750".getBytes(Constants.ISO_8859_1);
+
+			for (int i = 0; i < b_prefix.length && i < id.length; i++) {
+				id[i] = b_prefix[i];
 			}
 		}
 		

--- a/core/src/com/biglybt/pifimpl/local/ddb/DDBaseHelpers.java
+++ b/core/src/com/biglybt/pifimpl/local/ddb/DDBaseHelpers.java
@@ -22,6 +22,7 @@ package com.biglybt.pifimpl.local.ddb;
 import java.io.*;
 import java.util.*;
 
+import com.biglybt.core.util.Constants;
 import com.biglybt.core.util.Debug;
 import com.biglybt.core.util.HashWrapper;
 import com.biglybt.core.util.SHA1Simple;
@@ -54,13 +55,8 @@ DDBaseHelpers
 
 		}else if ( obj instanceof String ){
 
-			try{
-				res = ((String)obj).getBytes("UTF-8");
+			res = ((String) obj).getBytes(Constants.UTF_8);
 
-			}catch( UnsupportedEncodingException e ){
-
-				throw( new DistributedDatabaseException( "charset error", e ));
-			}
 		}else if (	obj instanceof Byte ||
 					obj instanceof Short ||
 					obj instanceof Integer ||
@@ -101,19 +97,11 @@ DDBaseHelpers
 		throws DistributedDatabaseException
 	{
 		if ( target == byte[].class ){
-
 			return( data );
 
 		}else if ( target == String.class ){
+			return new String(data, Constants.UTF_8);
 
-			try{
-
-				return( new String( data, "UTF-8" ));
-
-			}catch( UnsupportedEncodingException e ){
-
-				throw( new DistributedDatabaseException( "charset error", e ));
-			}
 		}else{
 
 			try{

--- a/core/src/com/biglybt/plugin/net/buddy/BuddyPluginAZ2.java
+++ b/core/src/com/biglybt/plugin/net/buddy/BuddyPluginAZ2.java
@@ -22,7 +22,6 @@ package com.biglybt.plugin.net.buddy;
 
 import java.util.*;
 
-import com.biglybt.core.internat.MessageText;
 import com.biglybt.core.util.*;
 import com.biglybt.pif.PluginInterface;
 import com.biglybt.pif.torrent.Torrent;
@@ -125,14 +124,9 @@ BuddyPluginAZ2
 		Map	reply = new HashMap();
 
 		if ( type == RT_AZ2_REQUEST_MESSAGE ){
-
-			try{
-				String	msg = new String( (byte[])request.get( "msg" ), "UTF8" );
-
-				from_buddy.setLastMessageReceived( msg );
-
-			}catch( Throwable e ){
-
+			byte[] msgBytes = (byte[]) request.get("msg");
+			if (msgBytes != null) {
+				from_buddy.setLastMessageReceived(new String(msgBytes, Constants.UTF_8));
 			}
 
 			reply.put( "type", new Long( RT_AZ2_REPLY_MESSAGE ));

--- a/core/src/com/biglybt/plugin/net/buddy/BuddyPluginBeta.java
+++ b/core/src/com/biglybt/plugin/net/buddy/BuddyPluginBeta.java
@@ -821,11 +821,8 @@ BuddyPluginBeta implements DataSourceImporter, AEDiagnosticsEvidenceGenerator {
 		String		name,
 		String		value )
 	{
-		try{
-			setByteArrayOption( net, key, name, value.getBytes( "UTF-8" ));
-
-		}catch( Throwable e ){
-
+		if (value != null) {
+			setByteArrayOption(net, key, name, value.getBytes(Constants.UTF_8));
 		}
 	}
 
@@ -839,13 +836,7 @@ BuddyPluginBeta implements DataSourceImporter, AEDiagnosticsEvidenceGenerator {
 		byte[]	bytes = getByteArrayOption( net, key, name );
 
 		if ( bytes != null ){
-
-			try{
-				return( new String( bytes, "UTF-8" ));
-
-			}catch( Throwable e ){
-
-			}
+			return new String(bytes, Constants.UTF_8);
 		}
 
 		return( def );
@@ -877,34 +868,18 @@ BuddyPluginBeta implements DataSourceImporter, AEDiagnosticsEvidenceGenerator {
 		return( null );
 	}
 
-	private String
-	encodeKey(
-		String	key )
-	{
-		try{
-			return( Base32.encode( key.getBytes( "UTF-8" )));
-
-		}catch( Throwable e ){
-
-			Debug.out( e);
-
-			return( "" );
+	private String encodeKey(String key) {
+		if (key != null) {
+			return Base32.encode(key.getBytes(Constants.UTF_8));
 		}
+		return "";
 	}
 
-	private String
-	decodeKey(
-		String		key )
-	{
-		try{
-			return( new String( Base32.decode( key ),"UTF-8" ));
-
-		}catch( Throwable e ){
-
-			Debug.out( e);
-
-			return( "" );
+	private String decodeKey(String key) {
+		if ( key != null) {
+			return new String(Base32.decode(key), Constants.UTF_8);
 		}
+		return "";
 	}
 
 	private Object
@@ -6931,7 +6906,6 @@ BuddyPluginBeta implements DataSourceImporter, AEDiagnosticsEvidenceGenerator {
 		public String
 		getMessage()
 		{
-			try{
 				String	report = (String)map.get( "error" );
 
 				if ( report != null ){
@@ -6963,20 +6937,11 @@ BuddyPluginBeta implements DataSourceImporter, AEDiagnosticsEvidenceGenerator {
 
 					if ( msg_bytes != null ){
 
-						return( new String( msg_bytes, "UTF-8" ));
-					}
+					return new String(msg_bytes, Constants.UTF_8);
 				}
-
-
-
-				return( new String((byte[])map.get( "content" ), "UTF-8" ));
-
-			}catch( Throwable e ){
-
-				Debug.out( e );
-
-				return( "" );
 			}
+
+			return new String((byte[]) map.get("content"), Constants.UTF_8);
 		}
 
 		public byte[]
@@ -7145,15 +7110,10 @@ BuddyPluginBeta implements DataSourceImporter, AEDiagnosticsEvidenceGenerator {
 				byte[] nick = (byte[])payload.get( "nick" );
 
 				if ( nick != null ){
+					String str = new String(nick, Constants.UTF_8);
 
-					try{
-						String str = new String( nick, "UTF-8" );
-
-						if ( str.length() > 0 ){
-
-							return( str );
-						}
-					}catch( Throwable e ){
+					if (str.length() > 0) {
+						return str;
 					}
 				}
 			}

--- a/core/src/com/biglybt/plugin/net/buddy/BuddyPluginUtils.java
+++ b/core/src/com/biglybt/plugin/net/buddy/BuddyPluginUtils.java
@@ -593,23 +593,15 @@ BuddyPluginUtils
 			// use torrent name here to canonicalize things in case user has renamed download display name
 			// also it is more important to get a consistent string rather than something correctly localised
 
-		String	torrent_name = null;
+		TOTorrent to_torrent = PluginCoreUtils.unwrap( torrent );
 
-		try{
-			TOTorrent to_torrent = PluginCoreUtils.unwrap( torrent );
+		String torrent_name = to_torrent.getUTF8Name();
 
-			torrent_name = to_torrent.getUTF8Name();
-
-			if ( torrent_name == null ){
-
-				torrent_name = new String( to_torrent.getName(), "UTF-8" );
-			}
-		}catch( Throwable e ){
-
+		if (torrent_name == null && to_torrent.getName() != null) {
+			torrent_name = new String(to_torrent.getName(), Constants.UTF_8);
 		}
 
 		if ( torrent_name == null ){
-
 			torrent_name = torrent.getName();
 		}
 

--- a/core/src/com/biglybt/ui/common/table/impl/TableColumnImpl.java
+++ b/core/src/com/biglybt/ui/common/table/impl/TableColumnImpl.java
@@ -20,7 +20,6 @@
 
 package com.biglybt.ui.common.table.impl;
 
-import java.io.UnsupportedEncodingException;
 import java.util.*;
 
 import com.biglybt.core.config.COConfigurationManager;
@@ -1057,13 +1056,10 @@ public class TableColumnImpl
 			if (o instanceof String) {
 				return (String) o;
 			} else if (o instanceof byte[]) {
-				try {
-					String s = new String((byte[]) o, "utf-8");
-					// write it back to the map, so we don't continually create new String objects
-					userData.put(key, s);
-					return( s );
-				} catch (UnsupportedEncodingException e) {
-				}
+				String s = new String((byte[]) o, Constants.UTF_8);
+				// write it back to the map, so we don't continually create new String objects
+				userData.put(key, s);
+				return( s );
 			}
 		}
 		return null;

--- a/core/src/com/biglybt/update/CoreUpdateChecker.java
+++ b/core/src/com/biglybt/update/CoreUpdateChecker.java
@@ -328,16 +328,9 @@ CoreUpdateChecker
 				byte[]	info_b = (byte[])decoded.get( "info" );
 	
 				String	info = null;
-	
+
 				if ( info_b != null ){
-	
-					try{
-						info = new String( info_b, "UTF-8" );
-	
-					}catch( Throwable e ){
-	
-						Debug.printStackTrace( e );
-					}
+					info = new String(info_b, Constants.UTF_8);
 				}
 	
 				byte[] info_url_bytes = (byte[])decoded.get("info_url");
@@ -503,15 +496,7 @@ CoreUpdateChecker
 
 			  if ( message_bytes != null && message_bytes.length > 0 ){
 
-				  String  message;
-
-				  try{
-					  message = new String(message_bytes, "UTF-8" );
-
-				  }catch( Throwable e ){
-
-					  message = new String( message_bytes );
-				  }
+					String message = new String(message_bytes, Constants.UTF_8);
 
 				  String sig_key;
 

--- a/core/src/com/biglybt/util/JSONUtils.java
+++ b/core/src/com/biglybt/util/JSONUtils.java
@@ -17,7 +17,6 @@
 
 package com.biglybt.util;
 
-import java.io.UnsupportedEncodingException;
 import java.util.*;
 
 import org.gudy.bouncycastle.util.encoders.Base64;
@@ -25,6 +24,7 @@ import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
 
+import com.biglybt.core.util.Constants;
 import com.biglybt.core.util.Debug;
 
 
@@ -121,10 +121,7 @@ public class JSONUtils
 			Object[] array = (Object[]) value;
 			value = encodeToJSONArray(Arrays.asList(array));
 		} else if (value instanceof byte[]) {
-			try {
-				value = new String((byte[]) value, "utf-8");
-			} catch (UnsupportedEncodingException e) {
-			}
+			value = new String((byte[]) value, Constants.UTF_8);
 		} else if (value instanceof boolean[]) {
 			boolean[] array = (boolean[]) value;
 			ArrayList<Object> list = new ArrayList<>();
@@ -151,9 +148,6 @@ public class JSONUtils
 	}
 
 	/**
-	 * @param value
-	 * @return
-	 *
 	 * @since 3.0.1.5
 	 */
 	private static JSONArray encodeToJSONArray(Collection list) {

--- a/core/src/com/biglybt/util/MapUtils.java
+++ b/core/src/com/biglybt/util/MapUtils.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import com.biglybt.core.util.Constants;
 import com.biglybt.core.util.UrlUtils;
 import org.gudy.bouncycastle.util.encoders.Base64;
 
@@ -90,26 +91,21 @@ public class MapUtils
 		if (map == null) {
 			return def;
 		}
-		try {
-			Object o = map.get(key);
-			if (o == null && !map.containsKey(key)) {
-				return def;
-			}
-			// NOTE: The above returns def when map doesn't contain the key,
-			//       which suggests below we would return the null when o is null.
-			//       But we don't! And now, some callers rely on this :(
-
-			if (o instanceof String) {
-				return (String) o;
-			}
-			if (o instanceof byte[]) {
-				return new String((byte[]) o, "utf-8");
-			}
-			return def;
-		} catch (Throwable t) {
-			Debug.out(t);
+		Object o = map.get(key);
+		if (o == null && !map.containsKey(key)) {
 			return def;
 		}
+		// NOTE: The above returns def when map doesn't contain the key,
+		//       which suggests below we would return the null when o is null.
+		//       But we don't! And now, some callers rely on this :(
+
+		if (o instanceof String) {
+			return (String) o;
+		}
+		if (o instanceof byte[]) {
+			return new String((byte[]) o, Constants.UTF_8);
+		}
+		return def;
 	}
 
 	public static String[]
@@ -137,12 +133,7 @@ public class MapUtils
 		if ( obj instanceof String ){
 			return((String)obj);
 		}else if ( obj instanceof byte[]){
-
-			try{
-				return new String((byte[])obj, "UTF-8");
-			}catch( Throwable e ){
-
-			}
+			return new String((byte[]) obj, Constants.UTF_8);
 		}
 		return( null );
 	}
@@ -156,14 +147,10 @@ public class MapUtils
 			Debug.out( "Map is null!" );
 			return;
 		}
-		try{
-			if ( val == null ){
-				map.remove( key );
-			}else{
-				map.put( key, val.getBytes( "utf-8" ));
-			}
-		}catch( Throwable e ){
-			Debug.out(e);
+		if (val == null) {
+			map.remove(key);
+		} else {
+			map.put(key, val.getBytes(Constants.UTF_8));
 		}
 	}
 
@@ -423,13 +410,8 @@ public class MapUtils
 
 			}else if ( obj instanceof byte[] ){
 
-				try{
-					res[i] = new String((byte[])obj, "UTF-8" );
+				res[i] = new String((byte[])obj, Constants.UTF_8);
 
-				}catch( UnsupportedEncodingException e ){
-
-					e.printStackTrace();
-				}
 			}
 		}
 
@@ -446,15 +428,8 @@ public class MapUtils
 
 		map.put( key, l );
 
-		for (int i=0;i<data.length;i++){
-
-			try{
-				l.add( data[i].getBytes( "UTF-8" ));
-
-			}catch( UnsupportedEncodingException e ){
-
-				e.printStackTrace();
-			}
+		for (String datum : data) {
+			l.add(datum.getBytes(Constants.UTF_8));
 		}
 	}
 

--- a/uis/src/com/biglybt/plugin/net/buddy/swt/BuddyPluginViewChat.java
+++ b/uis/src/com/biglybt/plugin/net/buddy/swt/BuddyPluginViewChat.java
@@ -32,6 +32,7 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.*;
 
+import com.biglybt.core.util.Constants;
 import com.biglybt.core.util.Debug;
 import com.biglybt.pif.utils.LocaleUtilities;
 import com.biglybt.plugin.net.buddy.*;
@@ -344,13 +345,7 @@ BuddyPluginViewChat
 	{
 		Map	msg = new HashMap();
 
-		try{
-			msg.put( "line", text.getBytes( "UTF-8" ));
-
-		}catch( Throwable e ){
-
-			msg.put( "line", text.getBytes());
-		}
+		msg.put("line", text.getBytes(Constants.UTF_8));
 
 		logChatMessage( plugin.getNickname( chat.getPluginNetwork().isPublicNetwork()), Colors.green, msg );
 
@@ -397,15 +392,7 @@ BuddyPluginViewChat
 	{
 		byte[]	line = (byte[])map.get( "line" );
 
-		String msg;
-
-		try{
-			msg = new String( line, "UTF-8" );
-
-		}catch( Throwable e ){
-
-			msg = new String( line );
-		}
+		String msg = new String(line, Constants.UTF_8);
 
 		if ( buddy_name.length() > 32 ){
 

--- a/uis/src/com/biglybt/ui/common/UIConst.java
+++ b/uis/src/com/biglybt/ui/common/UIConst.java
@@ -136,10 +136,7 @@ public class UIConst
 				}
 			}
 
-			try {
-				sb.append(new String(newOut.toByteArray(), "utf8"));
-			} catch (UnsupportedEncodingException e) {
-			}
+			sb.append(new String(newOut.toByteArray(), Constants.UTF_8));
 			return sb.toString();
 		} finally {
 			System.setOut(oldOut);

--- a/uis/src/com/biglybt/ui/console/util/StringEncrypter.java
+++ b/uis/src/com/biglybt/ui/console/util/StringEncrypter.java
@@ -17,7 +17,7 @@
 
 package com.biglybt.ui.console.util;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.KeySpec;
@@ -30,6 +30,8 @@ import javax.crypto.spec.DESKeySpec;
 import javax.crypto.spec.DESedeKeySpec;
 
 import org.gudy.bouncycastle.util.encoders.Base64;
+
+import com.biglybt.core.util.Constants;
 
 /**
  * utility class to encrypt strings. this class was taken from the examples at:
@@ -45,7 +47,7 @@ public class StringEncrypter
 	private SecretKeyFactory     keyFactory;
 	private Cipher               cipher;
 
-	private static final String     UNICODE_FORMAT               = "UTF8";
+	private static final Charset UNICODE_FORMAT = Constants.UTF_8;
 
 	public StringEncrypter( String encryptionScheme ) throws EncryptionException
 	{
@@ -83,10 +85,6 @@ public class StringEncrypter
 
 		}
 		catch (InvalidKeyException e)
-		{
-			throw new EncryptionException( e );
-		}
-		catch (UnsupportedEncodingException e)
 		{
 			throw new EncryptionException( e );
 		}
@@ -154,9 +152,6 @@ public class StringEncrypter
 
 	public static class EncryptionException extends Exception
 	{
-		/**
-		 *
-		 */
 		private static final long serialVersionUID = -8767982102667004210L;
 
 		public EncryptionException( Throwable t )

--- a/uis/src/com/biglybt/ui/swt/config/PasswordSwtParameter.java
+++ b/uis/src/com/biglybt/ui/swt/config/PasswordSwtParameter.java
@@ -17,7 +17,6 @@
  */
 package com.biglybt.ui.swt.config;
 
-import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
 
 import org.eclipse.swt.SWT;
@@ -26,6 +25,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Text;
 
 import com.biglybt.core.internat.MessageText;
+import com.biglybt.core.util.Constants;
 import com.biglybt.core.util.Debug;
 import com.biglybt.core.util.SHA1Hasher;
 import com.biglybt.pifimpl.local.ui.config.PasswordParameterImpl;
@@ -165,10 +165,7 @@ public class PasswordSwtParameter
 			if (value == null) {
 				return;
 			}
-			try {
-				setUiValue(new String(value, "utf8"));
-			} catch (UnsupportedEncodingException ignore) {
-			}
+			setUiValue(new String(value, Constants.UTF_8));
 		}
 	}
 


### PR DESCRIPTION
Eliminated try-catch constructs for new String(byte[], (String)charsetname) creations.

I've only changed the simple cases. Other cases of try-catch(Throwable/IOException) with multiple sources of exceptions are left untouched.