### PR TITLE
SWT: Only use setBackgroundMode(SWT.INHERIT_FORCE) on Win

### DIFF
--- a/uis/src/com/biglybt/ui/swt/TorrentMenuFancy.java
+++ b/uis/src/com/biglybt/ui/swt/TorrentMenuFancy.java
@@ -424,7 +424,10 @@ public class TorrentMenuFancy
 		shellLayout.marginWidth = shellLayout.marginHeight = SHELL_MARGIN;
 
 		shell.setLayout(shellLayout);
-		shell.setBackgroundMode(SWT.INHERIT_FORCE);
+		if (Constants.isWindows) {
+			// Windows SWT Bug: button and label BGs won't draw properly without INHERIT FORCE
+			shell.setBackgroundMode(SWT.INHERIT_FORCE);
+		}
 
 		topArea = new Composite(shell, SWT.DOUBLE_BUFFERED);
 		detailArea = new Composite(shell, SWT.DOUBLE_BUFFERED);
@@ -2512,7 +2515,11 @@ public class TorrentMenuFancy
 
 		HeaderInfo headerInfo = new HeaderInfo(id, runnable, composite);
 
-		composite.setBackgroundMode(SWT.INHERIT_FORCE);
+		if (Constants.isWindows) {
+			// Windows SWT Bug: button and label BGs won't draw properly without INHERIT FORCE
+			composite.setBackgroundMode(SWT.INHERIT_FORCE);
+		}
+
 		FillLayout fillLayout = new FillLayout();
 		fillLayout.marginWidth = 6;
 		fillLayout.marginHeight = 2;

--- a/uis/src/com/biglybt/ui/swt/devices/TranscodeChooser.java
+++ b/uis/src/com/biglybt/ui/swt/devices/TranscodeChooser.java
@@ -34,6 +34,7 @@ import com.biglybt.core.config.COConfigurationManager;
 import com.biglybt.core.devices.Device;
 import com.biglybt.core.devices.*;
 import com.biglybt.core.internat.MessageText;
+import com.biglybt.core.util.Constants;
 import com.biglybt.core.util.Debug;
 import com.biglybt.ui.swt.Messages;
 import com.biglybt.ui.swt.UIFunctionsManagerSWT;
@@ -648,7 +649,10 @@ public abstract class TranscodeChooser
 
 	private void createDeviceList(SWTSkinObjectContainer soDeviceList) {
 		Composite parent = soDeviceList.getComposite();
-		parent.setBackgroundMode(SWT.INHERIT_FORCE);
+		if (Constants.isWindows) {
+			// Windows SWT Bug: button and label BGs won't draw properly without INHERIT FORCE
+			parent.setBackgroundMode(SWT.INHERIT_FORCE);
+		}
 		FormLayout layout = new FormLayout();
 		layout.marginLeft = 10;
 		layout.marginHeight = 15;

--- a/uis/src/com/biglybt/ui/swt/shells/opentorrent/OpenTorrentOptionsWindow.java
+++ b/uis/src/com/biglybt/ui/swt/shells/opentorrent/OpenTorrentOptionsWindow.java
@@ -5963,7 +5963,11 @@ public class OpenTorrentOptionsWindow
 		private void setupUpDownLimitOption(SWTSkinObjectContainer so) {
 			Composite parent = so.getComposite();
 
-			parent.setBackgroundMode( SWT.INHERIT_FORCE );	// win 7 classic theme shows grey background without this
+			if (Constants.isWindows) {
+				// Windows SWT Bug: button and label BGs won't draw properly without INHERIT FORCE
+				parent.setBackgroundMode( SWT.INHERIT_FORCE );
+			}
+
 			parent.setLayout( new GridLayout(4, false));
 
 			IntSwtParameter paramMaxUploadSpeed = new IntSwtParameter(parent,
@@ -6012,7 +6016,10 @@ public class OpenTorrentOptionsWindow
 		private void setupIPFilterOption(SWTSkinObjectContainer so) {
 			Composite parent = so.getComposite();
 
-			parent.setBackgroundMode( SWT.INHERIT_FORCE );	// win 7 classic theme shows grey background without this
+			if (Constants.isWindows) {
+				// Windows SWT Bug: button and label BGs won't draw properly without INHERIT FORCE
+				parent.setBackgroundMode( SWT.INHERIT_FORCE );
+			}
 			parent.setLayout( new GridLayout());
 
 			Button button = new Button(parent, SWT.CHECK | SWT.WRAP );
@@ -6033,8 +6040,10 @@ public class OpenTorrentOptionsWindow
 
 		private void setupPeerSourcesAndNetworkOptions(SWTSkinObjectContainer so) {
 			Composite parent = so.getComposite();
-			parent.setBackgroundMode( SWT.INHERIT_FORCE );	// win 7 classic theme shows grey background without this
-
+			if (Constants.isWindows) {
+				// Windows SWT Bug: button and label BGs won't draw properly without INHERIT FORCE
+				parent.setBackgroundMode( SWT.INHERIT_FORCE );
+			}
 
 			Composite peer_sources_composite = new Composite(parent, SWT.NULL);
 

--- a/uis/src/com/biglybt/ui/swt/skin/SWTSkinObjectCheckbox.java
+++ b/uis/src/com/biglybt/ui/swt/skin/SWTSkinObjectCheckbox.java
@@ -30,6 +30,7 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 
 import com.biglybt.core.util.AERunnable;
+import com.biglybt.core.util.Constants;
 import com.biglybt.core.util.Debug;
 import com.biglybt.ui.swt.Utils;
 
@@ -62,9 +63,11 @@ public class SWTSkinObjectCheckbox
 			createOn = (Composite) parent.getControl();
 		}
 
-		// WinXP Classic Theme will not bring though parent's background image
-		// without FORCEing the background mode
-		createOn.setBackgroundMode(SWT.INHERIT_FORCE);
+		if (Constants.isWindows) {
+			// WinXP Classic Theme will not bring though parent's background image
+			// without FORCEing the background mode
+			createOn.setBackgroundMode(SWT.INHERIT_FORCE);
+		}
 
 		int style = SWT.WRAP | SWT.CHECK;
 		String[] styles = properties.getStringArray(configID + ".style");

--- a/uis/src/com/biglybt/ui/swt/skin/SWTSkinObjectToggle.java
+++ b/uis/src/com/biglybt/ui/swt/skin/SWTSkinObjectToggle.java
@@ -30,6 +30,7 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 
 import com.biglybt.core.util.AERunnable;
+import com.biglybt.core.util.Constants;
 import com.biglybt.core.util.Debug;
 import com.biglybt.ui.swt.Utils;
 
@@ -61,9 +62,11 @@ public class SWTSkinObjectToggle
 			createOn = (Composite) parent.getControl();
 		}
 
-		// WinXP Classic Theme will not bring though parent's background image
-		// without FORCEing the background mode
-		createOn.setBackgroundMode(SWT.INHERIT_FORCE);
+		if (Constants.isWindows) {
+			// WinXP Classic Theme will not bring though parent's background image
+			// without FORCEing the background mode
+			createOn.setBackgroundMode(SWT.INHERIT_FORCE);
+		}
 
 		button = new Button(createOn, SWT.TOGGLE);
 		isToggled = false;

--- a/uis/src/com/biglybt/ui/swt/subscriptions/SubscriptionWizard.java
+++ b/uis/src/com/biglybt/ui/swt/subscriptions/SubscriptionWizard.java
@@ -59,6 +59,7 @@ import com.biglybt.core.internat.MessageText;
 import com.biglybt.core.util.AENetworkClassifier;
 import com.biglybt.core.util.AERunnable;
 import com.biglybt.core.util.ByteFormatter;
+import com.biglybt.core.util.Constants;
 import com.biglybt.pif.ui.UIManager;
 import com.biglybt.pif.ui.tables.TableCell;
 import com.biglybt.pif.ui.tables.TableCellAddedListener;
@@ -372,7 +373,10 @@ public class SubscriptionWizard {
 
 	private Composite createOptInComposite(Composite parent) {
 		Composite composite = new Composite(parent,SWT.NONE);
-		composite.setBackgroundMode(SWT.INHERIT_FORCE);
+		if (Constants.isWindows) {
+			// Windows SWT Bug: button and label BGs won't draw properly without INHERIT FORCE
+			composite.setBackgroundMode(SWT.INHERIT_FORCE);
+		}
 
 		Label description = new Label(composite,SWT.WRAP);
 		description.setFont(boldFont);

--- a/uis/src/com/biglybt/ui/swt/twistie/TwistieLabel.java
+++ b/uis/src/com/biglybt/ui/swt/twistie/TwistieLabel.java
@@ -37,6 +37,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 
 import com.biglybt.ui.swt.Utils;
+import com.biglybt.core.util.Constants;
 
 /**
  * A Label with a twistie graphic at the beginning; every time this label is clicked the
@@ -115,7 +116,10 @@ public class TwistieLabel
 	 */
 	public TwistieLabel(Composite parent, int style) {
 		super(parent, SWT.NONE);
-		setBackgroundMode(SWT.INHERIT_FORCE);
+		if (Constants.isWindows) {
+			// Windows SWT Bug: button and label BGs won't draw properly without INHERIT FORCE
+			setBackgroundMode(SWT.INHERIT_FORCE);
+		}
 		this.style = style;
 
 		GridLayout gLayout = new GridLayout();

--- a/uis/src/com/biglybt/ui/swt/twistie/TwistieSection.java
+++ b/uis/src/com/biglybt/ui/swt/twistie/TwistieSection.java
@@ -25,6 +25,7 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 
 import com.biglybt.ui.swt.Utils;
+import com.biglybt.core.util.Constants;
 
 public class TwistieSection
 	extends Composite
@@ -46,7 +47,10 @@ public class TwistieSection
 		*/
 	public TwistieSection(Composite parent, int style) {
 		super(parent, SWT.NONE);
-		setBackgroundMode(SWT.INHERIT_FORCE);
+		if (Constants.isWindows) {
+			// Windows SWT Bug: button and label BGs won't draw properly without INHERIT FORCE
+			setBackgroundMode(SWT.INHERIT_FORCE);
+		}
 		GridLayout gLayout = new GridLayout();
 		gLayout.marginHeight = 0;
 		gLayout.marginWidth = 0;
@@ -209,7 +213,10 @@ public class TwistieSection
 
 		public TwistieContentPanel(Composite parent, int style) {
 			super(parent, style);
-			setBackgroundMode(SWT.INHERIT_FORCE);
+			if (Constants.isWindows) {
+				// Windows SWT Bug: button and label BGs won't draw properly without INHERIT FORCE
+				setBackgroundMode(SWT.INHERIT_FORCE);
+			}
 		}
 
 		private void _setLayoutData(GridData gData) {

--- a/uis/src/com/biglybt/ui/swt/views/MyTorrentsView.java
+++ b/uis/src/com/biglybt/ui/swt/views/MyTorrentsView.java
@@ -839,7 +839,10 @@ public class MyTorrentsView
 				}
 			}
 
-			cCategoriesAndTags.setBackgroundMode(SWT.INHERIT_FORCE);
+			if (Constants.isWindows) {
+				// Windows SWT Bug: button and label BGs won't draw properly without INHERIT FORCE
+				cCategoriesAndTags.setBackgroundMode(SWT.INHERIT_FORCE);
+            }
 		}else if ( cCategoriesAndTags.isDisposed()){
 			return;
 		}

--- a/uis/src/com/biglybt/ui/swt/views/columnsetup/TableColumnSetupWindow.java
+++ b/uis/src/com/biglybt/ui/swt/views/columnsetup/TableColumnSetupWindow.java
@@ -380,7 +380,10 @@ public class TableColumnSetupWindow
 
 
 		Composite cProficiency = new Composite(cFilterArea, SWT.NONE);
-		cProficiency.setBackgroundMode(SWT.INHERIT_FORCE);
+		if (Constants.isWindows) {
+			// Windows SWT Bug: button and label BGs won't draw properly without INHERIT FORCE
+			cProficiency.setBackgroundMode(SWT.INHERIT_FORCE);
+		}
 		cProficiency.setLayout(new FormLayout());
 
 		Label lblProficiency = new Label(cProficiency, SWT.NONE);

--- a/uis/src/com/biglybt/ui/swt/views/skin/StandardButtonsArea.java
+++ b/uis/src/com/biglybt/ui/swt/views/skin/StandardButtonsArea.java
@@ -137,8 +137,10 @@ public abstract class StandardButtonsArea
 			// button area is supposed to be right aligned on both Windows+OSX
 
 		Composite cButtonArea = new Composite(cBottomArea, SWT.NONE);
-		// Fix button BG not right on Win7
-		cButtonArea.setBackgroundMode(SWT.INHERIT_FORCE);
+		if (Constants.isWindows) {
+			// Windows SWT Bug: button and label BGs won't draw properly without INHERIT FORCE
+			cButtonArea.setBackgroundMode(SWT.INHERIT_FORCE);
+		}
 		fd = new FormData();
 		fd.top = new FormAttachment(cCenterV, 0, SWT.CENTER);
 		fd.right = new FormAttachment(cCenterH, 0, SWT.LEFT);


### PR DESCRIPTION
Wrap all calls to `setBackgroundMode(SWT.INHERIT_FORCE`) in an `if (Constants.isWindows) {}` conditional, to prevent them from overriding correct styling on other platforms.

Fixes #1002