### PR TITLE
Add Editorconfig files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+root = true
+
+[*]
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.java]
+tab_width = 2
+indent_style = tab
+indent_size = 2
+continuation_indent_size = 2
+end_of_line = lf
+spaces_around_operators = true
+spaces_around_brackets = outside
+curly_bracket_next_line = false
+indent_brace_style = K&R
+quote_type = double
+
+[*.md]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = false

--- a/core/src/com/biglybt/core/download/.editorconfig
+++ b/core/src/com/biglybt/core/download/.editorconfig
@@ -1,0 +1,2 @@
+[DownloadManagerOptionsHandler.java]
+end_of_line = crlf

--- a/core/src/com/biglybt/core/tag/.editorconfig
+++ b/core/src/com/biglybt/core/tag/.editorconfig
@@ -1,0 +1,2 @@
+[{TagGroup.java,TagGroupListener.java,TagUtils.java,TagWrapper.java}]
+end_of_line = crlf

--- a/core/src/com/biglybt/core/tracker/.editorconfig
+++ b/core/src/com/biglybt/core/tracker/.editorconfig
@@ -1,0 +1,2 @@
+[{AllTrackersManager.java,alltrackers/AllTrackersManager.java}]
+end_of_line = crlf

--- a/core/src/com/biglybt/core/util/.editorconfig
+++ b/core/src/com/biglybt/core/util/.editorconfig
@@ -1,0 +1,2 @@
+[{AEMonitorOld.java,AESemaphoreOld.java,DataSourceResolver.java,protocol/URLConnectionExt.java}]
+end_of_line = crlf

--- a/core/src/com/biglybt/pif/messaging/generic/.editorconfig
+++ b/core/src/com/biglybt/pif/messaging/generic/.editorconfig
@@ -1,0 +1,2 @@
+[GenericMessageStartpoint.java]
+end_of_line = crlf

--- a/core/src/com/biglybt/pif/ui/components/.editorconfig
+++ b/core/src/com/biglybt/pif/ui/components/.editorconfig
@@ -1,0 +1,2 @@
+[UIButton.java]
+end_of_line = crlf

--- a/core/src/com/biglybt/pifimpl/local/ui/components/.editorconfig
+++ b/core/src/com/biglybt/pifimpl/local/ui/components/.editorconfig
@@ -1,0 +1,2 @@
+[UIButtonImpl.java]
+end_of_line = crlf

--- a/core/src/com/biglybt/plugin/net/buddy/.editorconfig
+++ b/core/src/com/biglybt/plugin/net/buddy/.editorconfig
@@ -1,0 +1,2 @@
+[{BuddyPlugin.java,PartialBuddy.java,PartialBuddyListener.java}]
+end_of_line = crlf

--- a/core/src/org/json/jsonjava/.editorconfig
+++ b/core/src/org/json/jsonjava/.editorconfig
@@ -1,0 +1,2 @@
+[JSONJava.java]
+end_of_line = crlf


### PR DESCRIPTION
This commit installs a top-level `.editorconfig` file which attempts to incorporate, to the extent supported, the rules present in the `PreferencesJavaCodeStyleFormatter.xml` config and/or laid out in the `CODING_GUIDELINES.md` file.

Most rules are applied to `*.java` files only, although a few are applied for all files:
```
[*]
charset = utf-8
trim_trailing_whitespace = true
insert_final_newline = true
```

Markdown files are also explicitly configured to 2-space indents.

Additionally, local `.editorconfigs` are installed at each level of the tree which contains existing `.java` files in CRLF line ending format, to explicitly preserve that format on those files only.

For example, `core/src/com/biglybt/core/util/.editorconfig` contains:
```
[{AEMonitorOld.java,AESemaphoreOld.java,DataSourceResolver.java,protocol/URLConnectionExt.java}]
end_of_line = crlf
```