### PR TITLE
Use maven-enforcer instead of prerequisites

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,10 +33,6 @@
 		-->
 	</repositories>
 
-    <prerequisites>
-        <maven>3.3.9</maven>
-    </prerequisites>
-
 	<modules>
 		<module>core</module>
 		<module>uis</module>
@@ -129,6 +125,26 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-enforcer-plugin</artifactId>
+					<version>3.0.0-M2</version>
+					<executions>
+						<execution>
+							<id>enforce-maven</id>
+							<goals>
+								<goal>enforce</goal>
+							</goals>
+							<configuration>
+								<rules>
+									<requireMavenVersion>
+										<version>3.3.9</version>
+									</requireMavenVersion>
+								</rules>    
+							</configuration>
+						</execution>
+					</executions>
+				</plugin>
+				<plugin>
 					<groupId>io.takari.maven.plugins</groupId>
 					<artifactId>takari-lifecycle-plugin</artifactId>
 					<version>1.12.6</version>
@@ -161,6 +177,10 @@
 			</plugins>
 		</pluginManagement>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+			</plugin>
 			<plugin>
 				<groupId>io.takari.maven.plugins</groupId>
 				<artifactId>takari-lifecycle-plugin</artifactId>


### PR DESCRIPTION
Running on the command line, Maven got complainey about the `<prerequisites>` for maven version in `pom.xml`, which are [no longer used](https://maven.apache.org/pom.html#Prerequisites) in Maven 3. Instead, the `maven-enforcer-plugin` provides the same functionality.

Before:
```console
$ mvn -N compile    
[INFO] Scanning for projects...
[WARNING] The project com.biglybt:biglybt-parent:pom:1.6.0.1-SNAPSHOT uses 
prerequisites which is only intended for maven-plugin projects but not for non 
maven-plugin projects. For such purposes you should use the maven-enforcer-plugin. 
See https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html
[INFO] 
[INFO] ---------------------< com.biglybt:biglybt-parent >---------------------
[INFO] Building BiglyBT - Parent 1.6.0.1-SNAPSHOT
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ biglybt-parent ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 0.617 s
[INFO] Finished at: 2019-04-28T20:02:21-04:00
[INFO] ------------------------------------------------------------------------

$ mvn -N io.takari:maven:0.7.6:wrapper -Dmaven=3.2.3
[INFO] Scanning for projects...
[WARNING] The project com.biglybt:biglybt-parent:pom:1.6.0.1-SNAPSHOT uses 
prerequisites which is only intended for maven-plugin projects but not for non 
maven-plugin projects. For such purposes you should use the maven-enforcer-plugin. 
See https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html
[INFO] 
[INFO] ---------------------< com.biglybt:biglybt-parent >---------------------
[INFO] Building BiglyBT - Parent 1.6.0.1-SNAPSHOT
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- maven:0.7.6:wrapper (default-cli) @ biglybt-parent ---
[INFO] 
[INFO] Maven Wrapper version 0.5.5 has been successfully set up for your project.
[INFO] Using Apache Maven: 3.2.3
[INFO] Repo URL in properties file: https://repo.maven.apache.org/maven2
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 0.673 s
[INFO] Finished at: 2019-04-28T20:11:20-04:00
[INFO] ------------------------------------------------------------------------

$ ./mvnw -N compile
[INFO] Scanning for projects...
[INFO]                                                                         
[INFO] ------------------------------------------------------------------------
[INFO] Building BiglyBT - Parent 1.6.0.1-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 0.374 s
[INFO] Finished at: 2019-04-28T20:11:32-04:00
[INFO] Final Memory: 9M/150M
[INFO] ------------------------------------------------------------------------

```

After:
```console
$ mvn -N compile
[INFO] Scanning for projects...
[INFO] 
[INFO] ---------------------< com.biglybt:biglybt-parent >---------------------
[INFO] Building BiglyBT - Parent 1.6.0.1-SNAPSHOT
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (enforce-maven) @ biglybt-parent ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 0.780 s
[INFO] Finished at: 2019-04-28T20:03:36-04:00
[INFO] ------------------------------------------------------------------------

$ mvn -N io.takari:maven:0.7.6:wrapper -Dmaven=3.2.3
[INFO] Scanning for projects...
[INFO] 
[INFO] ---------------------< com.biglybt:biglybt-parent >---------------------
[INFO] Building BiglyBT - Parent 1.6.0.1-SNAPSHOT
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- maven:0.7.6:wrapper (default-cli) @ biglybt-parent ---
[INFO] 
[INFO] Maven Wrapper version 0.5.5 has been successfully set up for your project.
[INFO] Using Apache Maven: 3.2.3
[INFO] Repo URL in properties file: https://repo.maven.apache.org/maven2
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 0.675 s
[INFO] Finished at: 2019-04-28T20:04:37-04:00
[INFO] ------------------------------------------------------------------------

$ ./mvnw -N compile
[INFO] Scanning for projects...
[INFO]                                                                         
[INFO] ------------------------------------------------------------------------
[INFO] Building BiglyBT - Parent 1.6.0.1-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (enforce-maven) @ biglybt-parent ---
[WARNING] Rule 0: org.apache.maven.plugins.enforcer.RequireMavenVersion failed with message:
Detected Maven Version: 3.2.3 is not in the allowed range 3.3.9.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
# # (etc...) 

$ mvn -N io.takari:maven:0.7.6:wrapper -Dmaven=3.5.3
[INFO] Scanning for projects...
[INFO] 
[INFO] ---------------------< com.biglybt:biglybt-parent >---------------------
[INFO] Building BiglyBT - Parent 1.6.0.1-SNAPSHOT
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- maven:0.7.6:wrapper (default-cli) @ biglybt-parent ---
[INFO] 
[INFO] Maven Wrapper version 0.5.5 has been successfully set up for your project.
[INFO] Using Apache Maven: 3.5.3
[INFO] Repo URL in properties file: https://repo.maven.apache.org/maven2
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 0.674 s
[INFO] Finished at: 2019-04-28T20:08:34-04:00
[INFO] ------------------------------------------------------------------------

$ ./mvnw -N compile                                 
[INFO] Scanning for projects...
[INFO] 
[INFO] ---------------------< com.biglybt:biglybt-parent >---------------------
[INFO] Building BiglyBT - Parent 1.6.0.1-SNAPSHOT
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (enforce-maven) @ biglybt-parent ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 0.784 s
[INFO] Finished at: 2019-04-28T20:08:42-04:00
[INFO] ------------------------------------------------------------------------
```