### PR TITLE
Add Editorconfig stanza for XML files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,6 +24,7 @@ tab_width = 2
 indent_style = tab
 indent_size = 2
 end_of_line = lf
+insert_final_newline = true
 
 [*.md]
 indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -19,6 +19,12 @@ quote_type = double
 #trim_trailing_whitespace = true
 insert_final_newline = true
 
+[*.xml]
+tab_width = 2
+indent_style = tab
+indent_size = 2
+end_of_line = lf
+
 [*.md]
 indent_style = space
 indent_size = 2

--- a/uis/.editorconfig
+++ b/uis/.editorconfig
@@ -1,0 +1,4 @@
+[pom.xml]
+indent_style = space
+indent_size = 4
+


### PR DESCRIPTION
This configures `*.xml` for tab indents and 2-space tabs, but special-cases `uis/pom.xml` which is formatted with 4-space indents.