### PR TITLE
Exclude .editorconfig files from jar

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -28,6 +28,7 @@
 				<excludes>
 					<exclude>**/*.java</exclude>
 					<exclude>**/*.class</exclude>
+					<exclude>**/.editorconfig</exclude>
 				</excludes>
 			</resource>
 		</resources>

--- a/uis/pom.xml
+++ b/uis/pom.xml
@@ -28,6 +28,7 @@
                 <excludes>
                     <exclude>**/*.java</exclude>
                     <exclude>**/*.class</exclude>
+                    <exclude>**/.editorconfig</exclude>
                 </excludes>
             </resource>
         </resources>


### PR DESCRIPTION
This will keep the `.editorconfig` files out of the packaged Jar:

```console
$ git co master
$ mvn package
[...]
$ jar tvf uis/target/BiglyBT.jar|grep -i editorconfig
    56 Tue Jan 01 03:00:00 EST 1980 com/biglybt/core/download/.editorconfig
    89 Tue Jan 01 03:00:00 EST 1980 com/biglybt/core/tag/.editorconfig
    83 Tue Jan 01 03:00:00 EST 1980 com/biglybt/core/tracker/.editorconfig
   116 Tue Jan 01 03:00:00 EST 1980 com/biglybt/core/util/.editorconfig
    51 Tue Jan 01 03:00:00 EST 1980 com/biglybt/pif/messaging/generic/.editorconfig
    35 Tue Jan 01 03:00:00 EST 1980 com/biglybt/pif/ui/components/.editorconfig
    39 Tue Jan 01 03:00:00 EST 1980 com/biglybt/pifimpl/local/ui/components/.editorconfig
    84 Tue Jan 01 03:00:00 EST 1980 com/biglybt/plugin/net/buddy/.editorconfig
    35 Tue Jan 01 03:00:00 EST 1980 org/json/jsonjava/.editorconfig
$ git co exclude-editorconfig
$ mvn package
[...]
$ jar tvf uis/target/BiglyBT.jar|grep -i editorconfig
$
```