### PR TITLE
Port to latest bouncycastle API

### DIFF
--- a/core/src/com/biglybt/core/security/CryptoECCUtils.java
+++ b/core/src/com/biglybt/core/security/CryptoECCUtils.java
@@ -141,7 +141,7 @@ CryptoECCUtils
    			throw( new CryptoManagerException( "Invalid public key" ));
    		}
 
-   		return ((ECPublicKey)pubkey).getQ().getEncoded();
+   		return ((ECPublicKey)pubkey).getQ().getEncoded(false);
    	}
 
 


### PR DESCRIPTION
Acording this commit [1]  Point compression was removed in bouncycastle, avoid use of removed API

[1]
https://src.fedoraproject.org/rpms/azureus/c/3f7722f761931b107a3d50721a24a702ed34f442?branch=f33