### PR TITLE
Correct spelling of "SIMULTANEOUS"

### DIFF
--- a/core/src/com/biglybt/core/networkmanager/impl/tcp/TCPConnectionManager.java
+++ b/core/src/com/biglybt/core/networkmanager/impl/tcp/TCPConnectionManager.java
@@ -52,32 +52,32 @@ public class TCPConnectionManager {
   static int CONNECT_SELECT_LOOP_TIME			= 100;
   static int CONNECT_SELECT_LOOP_MIN_TIME		= 0;
 
-  static int MIN_SIMULTANIOUS_CONNECT_ATTEMPTS = 3;
-  public static int MAX_SIMULTANIOUS_CONNECT_ATTEMPTS;
+  static int MIN_SIMULTANEOUS_CONNECT_ATTEMPTS = 3;
+  public static int MAX_SIMULTANEOUS_CONNECT_ATTEMPTS;
 
   static int max_outbound_connections;
 
   static {
-    MAX_SIMULTANIOUS_CONNECT_ATTEMPTS = COConfigurationManager.getIntParameter( "network.max.simultaneous.connect.attempts" );
+    MAX_SIMULTANEOUS_CONNECT_ATTEMPTS = COConfigurationManager.getIntParameter( "network.max.simultaneous.connect.attempts" );
 
-    if( MAX_SIMULTANIOUS_CONNECT_ATTEMPTS < 1 ) { //should never happen, but hey
-   	 MAX_SIMULTANIOUS_CONNECT_ATTEMPTS = 1;
+    if( MAX_SIMULTANEOUS_CONNECT_ATTEMPTS < 1 ) { //should never happen, but hey
+   	 MAX_SIMULTANEOUS_CONNECT_ATTEMPTS = 1;
    	 COConfigurationManager.setParameter( "network.max.simultaneous.connect.attempts", 1 );
     }
 
-    MIN_SIMULTANIOUS_CONNECT_ATTEMPTS = MAX_SIMULTANIOUS_CONNECT_ATTEMPTS - 2;
+    MIN_SIMULTANEOUS_CONNECT_ATTEMPTS = MAX_SIMULTANEOUS_CONNECT_ATTEMPTS - 2;
 
-    if( MIN_SIMULTANIOUS_CONNECT_ATTEMPTS < 1 ) {
-      MIN_SIMULTANIOUS_CONNECT_ATTEMPTS = 1;
+    if( MIN_SIMULTANEOUS_CONNECT_ATTEMPTS < 1 ) {
+      MIN_SIMULTANEOUS_CONNECT_ATTEMPTS = 1;
     }
 
     COConfigurationManager.addParameterListener( "network.max.simultaneous.connect.attempts", new ParameterListener() {
       @Override
       public void parameterChanged(String parameterName ) {
-        MAX_SIMULTANIOUS_CONNECT_ATTEMPTS = COConfigurationManager.getIntParameter( "network.max.simultaneous.connect.attempts" );
-        MIN_SIMULTANIOUS_CONNECT_ATTEMPTS = MAX_SIMULTANIOUS_CONNECT_ATTEMPTS - 2;
-        if( MIN_SIMULTANIOUS_CONNECT_ATTEMPTS < 1 ) {
-          MIN_SIMULTANIOUS_CONNECT_ATTEMPTS = 1;
+        MAX_SIMULTANEOUS_CONNECT_ATTEMPTS = COConfigurationManager.getIntParameter( "network.max.simultaneous.connect.attempts" );
+        MIN_SIMULTANEOUS_CONNECT_ATTEMPTS = MAX_SIMULTANEOUS_CONNECT_ATTEMPTS - 2;
+        if( MIN_SIMULTANEOUS_CONNECT_ATTEMPTS < 1 ) {
+          MIN_SIMULTANEOUS_CONNECT_ATTEMPTS = 1;
         }
       }
     });
@@ -312,7 +312,7 @@ public class TCPConnectionManager {
   void
   addNewOutboundRequests()
   {
-	  while( pending_attempts.size() + pending_pp_attempts.size() < MIN_SIMULTANIOUS_CONNECT_ATTEMPTS ){
+	  while( pending_attempts.size() + pending_pp_attempts.size() < MIN_SIMULTANEOUS_CONNECT_ATTEMPTS){
 
 		  ConnectionRequest cr = null;
 
@@ -861,7 +861,7 @@ public class TCPConnectionManager {
     	//check if our connect queue is stalled, and expand if so
     
     if ( 	num_stalled_requests == pending_attempts.size() && 
-    		pending_attempts.size() + pending_pp_attempts.size() < MAX_SIMULTANIOUS_CONNECT_ATTEMPTS ){
+    		pending_attempts.size() + pending_pp_attempts.size() < MAX_SIMULTANEOUS_CONNECT_ATTEMPTS){
 
     	ConnectionRequest cr =null;
 

--- a/core/src/com/biglybt/core/peer/impl/control/PEPeerControlImpl.java
+++ b/core/src/com/biglybt/core/peer/impl/control/PEPeerControlImpl.java
@@ -4665,7 +4665,7 @@ public class PEPeerControlImpl extends LogRelation implements PEPeerControl, Dis
 			return(ct_def);
 		}
 
-		int max_sim_con = TCPConnectionManager.MAX_SIMULTANIOUS_CONNECT_ATTEMPTS;
+		int max_sim_con = TCPConnectionManager.MAX_SIMULTANEOUS_CONNECT_ATTEMPTS;
 
 		// high, let's not mess with things
 
@@ -4863,7 +4863,7 @@ public class PEPeerControlImpl extends LogRelation implements PEPeerControl, Dis
 
 					// try and connect only as many as necessary
 
-					final int wanted = TCPConnectionManager.MAX_SIMULTANIOUS_CONNECT_ATTEMPTS
+					final int wanted = TCPConnectionManager.MAX_SIMULTANEOUS_CONNECT_ATTEMPTS
 							- num_waiting_establishments;
 
 					if(wanted > allowed){
@@ -4878,7 +4878,7 @@ public class PEPeerControlImpl extends LogRelation implements PEPeerControl, Dis
 					int udp_remaining = UDPNetworkManager.getSingleton().getConnectionManager()
 							.getMaxOutboundPermitted();
 
-					while(num_waiting_establishments < TCPConnectionManager.MAX_SIMULTANIOUS_CONNECT_ATTEMPTS
+					while(num_waiting_establishments < TCPConnectionManager.MAX_SIMULTANEOUS_CONNECT_ATTEMPTS
 							&& (tcp_remaining > 0 || udp_remaining > 0)){
 
 						if(!is_running)


### PR DESCRIPTION
(It's spelled correctly in `ICFG_NETWORK_MAX_SIMULTANEOUS_CONNECT_ATTEMPTS`, and the configuration path `network.max.simultaneous.connect.attempts`, but incorrectly in `TcpConnectionManager.{MIN,MAX}_SIMULTANIOUS_CONNECT_ATTEMPTS`.)
