### PR TITLE
Removing reflection use in NetUtils

### DIFF
--- a/core/src/com/biglybt/core/util/NetUtils.java
+++ b/core/src/com/biglybt/core/util/NetUtils.java
@@ -20,8 +20,6 @@
 
 package com.biglybt.core.util;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.net.*;
 import java.util.*;
 import java.util.regex.Pattern;
@@ -549,37 +547,15 @@ NetUtils
 			se = e;
 		}
 
-		// Java 7 has getByIndex
-		try {
-			Method mGetByIndex = NetworkInterface.class.getDeclaredMethod(
-					"getByIndex", int.class);
-			List<NetworkInterface> list = new ArrayList<>();
-			int i = 0;
-			do {
-				//NetworkInterface nif = NetworkInterface.getByIndex(i);
-				NetworkInterface nif = null;
-				try {
-					nif = (NetworkInterface) mGetByIndex.invoke(null, i);
-				} catch (IllegalAccessException e) {
-					break;
-				} catch (InvocationTargetException ignore) {
-					// getByIndex throws SocketException
-				}
-				if (nif != null) {
-					list.add(nif);
-				} else if (i > 0) {
-					break;
-				}
-				i++;
-			} while (true);
-			if (list.size() > 0) {
-				return Collections.enumeration(list);
-			}
-		} catch (NoSuchMethodException ignore) {
+		final List<NetworkInterface> list = new ArrayList<>();
+
+		collectNetworkInterfacesByIndex(list);
+
+		if (!list.isEmpty()) {
+			return Collections.enumeration(list);
 		}
 
 		// Worst case, try some common interface names
-		List<NetworkInterface> list = new ArrayList<>();
 		final String[] commonNames = {
 			"lo",
 			"eth",
@@ -611,10 +587,29 @@ NetUtils
 			} catch (Throwable ignore) {
 			}
 		}
-		if (list.size() > 0) {
+
+		if (!list.isEmpty()) {
 			return Collections.enumeration(list);
 		}
 
 		throw se;
 	}
+
+	private static void collectNetworkInterfacesByIndex(List<NetworkInterface> list) {
+		int i = 0;
+		do {
+			NetworkInterface nif = null;
+			try {
+				nif = NetworkInterface.getByIndex(i);
+			} catch (SocketException ignore) {
+			}
+			if (nif != null) {
+				list.add(nif);
+			} else if (i > 0) {
+				break;
+			}
+			i++;
+		} while (true);
+	}
+
 }


### PR DESCRIPTION
Removed this forward compatibility code as the Android SDK level 15 / JDK8 API is the current baseline. 
Wrapped it in a separate method. 

[NetworkInterface.getByIndex(int)](https://docs.oracle.com/javase/8/docs/api/java/net/NetworkInterface.html#getByIndex-int-) was introduced with Java 7.