### PR TITLE
Maven: Auto-exclude AENameServiceDescriptor based on JDK version

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -34,8 +34,9 @@
 		</resources>
 		<plugins>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
+				<groupId>io.takari.maven.plugins</groupId>
+				<artifactId>takari-lifecycle-plugin</artifactId>
+				<extensions>true</extensions>
 				<configuration>
 					<source>${java.version}</source>
 					<target>${java.version}</target>
@@ -43,5 +44,28 @@
 			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>java-9</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+				<jdk>[9,)</jdk>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>io.takari.maven.plugins</groupId>
+						<artifactId>takari-lifecycle-plugin</artifactId>
+						<configuration>
+							<excludes>
+								<exclude>**/core/util/spi/AENameServiceDescriptor.java</exclude>
+							</excludes>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 
 </project>


### PR DESCRIPTION
Building under JDK 1.8.0 / JDK 8, the `com.biglybt.core` classes can be compiled with the DNS SPI code in `...core.util.spi.AENameServiceDescriptor`. Thanks to the shim classes in `AENameServiceJava9.java` and `...Java12.java`, the compiled code can even be run under later JRE releases.

When building under JDK 9 or higher, `AENameServiceDescriptor.java` is uncompilable; the only option, [as @parg has noted](https://github.com/BiglySoftware/BiglyBT/issues/1017#issuecomment-873861491), is to "Just exclude the file from the build".

There's no reason that has to be a manual process, thanks to Maven's profiles feature. This PR adds a new profile, activated only when the Java version Maven is being run under is 9 or higher, that automatically excludes the `AENameServiceDescriptor.java` file from the build.

My tests were run on my Fedora 36 system, with multiple JRE releases installed.

With JRE 1.8.0, Maven compiled 2652 sources in core/:
```console
$ JAVA_HOME=/usr/lib/jvm/jre-1.8.0-openjdk mvn -B clean
$ JAVA_HOME=/usr/lib/jvm/jre-1.8.0-openjdk mvn -B package
--------8<--------
[INFO] --- takari-lifecycle-plugin:2.0.0:compile (default-compile) @ biglybt-core ---
[INFO] Previous incremental build state does not exist, performing full build
[INFO] Compiling 2652 sources to /home/ferd/Projects/BiglyBT/core/target/classes
--------8<--------
[INFO] Compiled 2652 out of 2652 sources (17450 ms)
```

With JRE 11, Maven compiled 265**1** sources successfully:
```console
$ JAVA_HOME=/usr/lib/jvm/jre-11-openjdk mvn -B clean
$ JAVA_HOME=/usr/lib/jvm/jre-11-openjdk mvn -B package
--------8<--------
[INFO] --- takari-lifecycle-plugin:2.0.0:compile (default-compile) @ biglybt-core ---
[INFO] Previous incremental build state does not exist, performing full build
[INFO] Compiling 2651 sources to /home/ferd/Projects/BiglyBT/core/target/classes
--------8<--------
[INFO] Compiled 2651 out of 2651 sources (39938 ms)
```

(JRE 17 and 18 builds fail for other reasons, it seems the code is not yet fully compatible with those Java releases.)

Note that no other configuration was required on my part, just changing which JRE Maven executed under. Assuming this works the same for Parg and doesn't interfere with the _official_ build process in any way, it should make life easier for   distro packagers and others who want to build BiglyBT themselves.