### PR TITLE
Maven: POM updates for services file location

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -59,7 +59,7 @@
 					<resource>
 						<targetPath>META-INF/services</targetPath>
 						<filtering>false</filtering>
-						<directory>src/services</directory>
+						<directory>src/META-INF/services</directory>
 						<includes>
 							<include>*.NameServiceDescriptor</include>
 						</includes>
@@ -75,6 +75,16 @@
 				<jdk>[9,)</jdk>
 			</activation>
 			<build>
+				<resources>
+					<resource>
+						<targetPath>META-INF/services</targetPath>
+						<filtering>false</filtering>
+						<directory>src/META-INF/services</directory>
+						<excludes>
+							<exclude>*.NameServiceDescriptor</exclude>
+						</excludes>
+					</resource>
+				</resources>
 				<plugins>
 					<plugin>
 						<groupId>io.takari.maven.plugins</groupId>


### PR DESCRIPTION
While attempting to make the inclusion of the `META-INF/services/` configuration file conditional, I moved it to a directory outside of the `META-INF` dir. That change was mostly inspired by [this example from the Maven docs](https://maven.apache.org/pom.html#resources), in the hope I could get away with including it by _default_, but still exclude it when a conditional profile is activated.

After that still didn't work, and I realized I'd have to have two profiles governing its inclusion/exclusion, the move became pointless. At that point I should've just put it back in its original location, to make the PR less disruptive to established tasks. I neglected to do that. My apologies.

Now that the file's restored to its original location, this PR updates the POM rules accordingly so that it's still included in JDK 8 builds, but excluded when building with JDK 9+.