### PR TITLE
GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,13 @@ jobs:
     - name: Package with Maven
       id: maven_package
       run: mvn package --file pom.xml
-    - run: mkdir staging && cp uis/target/BiglyBT.jar staging/
+    - name: Stage JAR file artifact
+      run: mkdir staging && cp uis/target/BiglyBT.jar staging/
       if: steps.maven_package.outcome == 'success'
     - name: Publish artifact
       if: steps.maven_package.outcome == 'success'
       uses: actions/upload-artifact@v3
       with:
-        name: BiglyBT_JDK_${{ matrix.java-version }}
+        name: BiglyBT_${{ runner.os }}_JDK_${{ matrix.java-version }}
         path: staging
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.continue-on-error }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version: [ '8', '11' ]
+        continue-on-error: [false]
+        include:
+          - java-version: '17'
+            continue-on-error: true
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{ matrix.java-version }}
+        distribution: 'temurin'
+        cache: maven
+    - name: Build with Maven
+      id: maven_compile
+      run: mvn compile --file pom.xml
+    - name: Package with Maven
+      id: maven_package
+      run: mvn package --file pom.xml
+    - run: mkdir staging && cp uis/target/BiglyBT.jar staging/
+      if: steps.maven_package.outcome == 'success'
+    - name: Publish artifact
+      if: steps.maven_package.outcome == 'success'
+      uses: actions/upload-artifact@v3
+      with:
+        name: BiglyBT_JDK_${{ matrix.java-version }}
+        path: staging
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,18 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.continue-on-error }}
 
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, macos-10.15, windows-latest]
         java-version: [ '8', '11' ]
         continue-on-error: [false]
         include:
-          - java-version: '17'
+          - os: ubuntu-latest
+            java-version: '17'
             continue-on-error: true
 
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: java
-
-jdk:
-  - oraclejdk8
-
-before_install:
-  - chmod +x mvnw

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.biglybt</groupId>
 		<artifactId>biglybt-parent</artifactId>
-		<version>2.5.0.1-SNAPSHOT</version>
+		<version>3.1.0.1-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -188,10 +188,6 @@
 		</plugins>
 	</build>
 
-	<prerequisites>
-		<maven>3.0.9</maven>
-	</prerequisites>
-
 	<scm>
 		<connection>scm:git:git@github.com:BiglySoftware/BiglyBT.git</connection>
 		<developerConnection>scm:git:git@github.com:BiglySoftware/BiglyBT.git</developerConnection>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.biglybt</groupId>
 	<artifactId>biglybt-parent</artifactId>
-	<version>2.5.0.1-SNAPSHOT</version>
+	<version>3.1.0.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>BiglyBT - Parent</name>
 

--- a/uis/pom.xml
+++ b/uis/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.biglybt</groupId>
         <artifactId>biglybt-parent</artifactId>
-        <version>2.5.0.1-SNAPSHOT</version>
+        <version>3.1.0.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>


### PR DESCRIPTION
Now that the repo is trivially buildable using Maven under common JDK versions, this PR adds GitHub CI runs under JDK 8 and 11 on all three OS platforms.

Any build issues or outright failures in a job will cause it to fail. If it does _not_ fail, the final `BiglyBT.jar` file is published as a build artifact (actually, as 6 build artifacts) which can be retrieved from the job summary view under the Actions tab for any run.

The workflow is configured to run a CI job for all pushes to and pull requests targeting the `master` branch. It is also defined with a `workflow_dispatch` trigger, which means committers can manually trigger a run against any branch via the repo 'Actions' tab.

A JDK 17 build job is also defined, running on Ubuntu only, but currently allowed to fail because it _is_ failing due to some issues the tests are raising regarding supposedly-missing translations. Those failures will still be logged as failures, but (unlike normally) those failures will not cause the other jobs in the workflow to immediately abort.

An example of a complete run with the submitted configuration:
https://github.com/ferdnyc/BiglyBT/actions/runs/2632563481

#### Other changes
* Deleted the ancient, vestigial Travis CI config file.

* Removed the `<prerequisites>` section of the parent POM, which was producing a warning as `<prerequisites>` is only for Maven plugin projects. For other project types the recommendation is to use the enforcer plugin, which we already are.

* Manually bumped the project version to `3.1.0.1-SNAPSHOT` in all three POM files as a one-time adjustment, since previously it was still `2.5.0.1-SNAPSHOT`. Keeping that up to date with every subsequent release isn't necessary, fortunately, because it sure would be annoying having to change it in three places every time.

    Since Maven 3.5.0, a feature is available called [CI Friendly Versions](https://maven.apache.org/maven-ci-friendly.html) which allows that information to be centralized and even made configurable at build time. However, it requires use of the `flatten-maven-plugin` to expand the version variables for export, and the flatten plugin [interacts](https://github.com/mojohaus/flatten-maven-plugin/issues/100) badly [with the](https://stackoverflow.com/questions/52552329/use-maven-flatten-plugin-and-maven-shade-plugin-at-the-same-time) Shade plugin, making it more trouble than it's worth at present.
