### PR TITLE
Maven: Convert WikiTest to a ParameterizedTest, make concurrent

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,7 +15,14 @@
 		<dependency>
 			<groupId>commons-cli</groupId>
 			<artifactId>commons-cli</artifactId>
-			<version>1.4</version>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,33 +40,30 @@
 
 	<dependencyManagement>
 		<dependencies>
-
 			<dependency>
 				<groupId>com.biglybt</groupId>
 				<artifactId>biglybt-core</artifactId>
 				<version>${project.version}</version>
 			</dependency>
-
+			<dependency>
+				<groupId>org.junit.jupiter</groupId>
+				<artifactId>junit-jupiter</artifactId>
+				<version>${junit.jupiter.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.assertj</groupId>
+				<artifactId>assertj-core</artifactId>
+				<version>3.12.1</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>commons-cli</groupId>
+				<artifactId>commons-cli</artifactId>
+				<version>1.4</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
-
-	<dependencies>
-
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter</artifactId>
-			<version>${junit.jupiter.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.assertj</groupId>
-			<artifactId>assertj-core</artifactId>
-			<version>3.12.1</version>
-			<scope>test</scope>
-		</dependency>
-
-	</dependencies>
 
 	<profiles>
 		<profile>
@@ -173,6 +170,13 @@
 				<plugin>
 					<artifactId>maven-surefire-plugin</artifactId>
 					<version>2.22.2</version>
+					<configuration>
+						<properties>
+							<configurationParameters>
+								junit.jupiter.execution.parallel.enabled = true
+							</configurationParameters>
+						</properties>
+					</configuration>
 				</plugin>
 			</plugins>
 		</pluginManagement>


### PR DESCRIPTION
With this PR:

* The test method in the WikiTest class is converted to a JUnit `@ParameterizedTest`, and a new `ArgumentsProvider` class wraps the stream of wiki names/urls into a stream of test arguments. JUnit calls the test method once for each URL tested. (A single monolithic test becomes 43 separate, single-URL tests.)
* An `@Execution(ExecutionMode.CONCURRENT)` annotation is added to the test, allowing JUnit to execute instances in parallel.
* JUnit parallel execution is enabled in the POM, but turned off by default. (Meaning: only tests explicitly annotated for parallel execution will be run concurrently — currently, that's only the WikiTest instances.)
* The WikiTest is modified to remove all extraneous output, since tests can now be interleaved and unnecessary, incremental output turns into a confusing jumble of partial writes to the console. Each test instance will now output **at most** one `WARNING` line in a single, atomic `System.err.println()` call. (Successful tests will output nothing at all.)
* The `HttpUrlConnection` `.disconnect()` method is no longer called at the end of each test, to facilitate possible reuse of the underlying network connection by other test instances. (Instead, the `InputStream` is explicitly instantiated, and then `.close()`d following each test.) [The `.disconnect()` method is [documented as](https://docs.oracle.com/javase/8/docs/api/java/net/HttpURLConnection.html#disconnect--), "Indicates that other requests to the server are unlikely in the near future.", which is obviously not the case if there are other test instances to execute.

On my system, parallelizing the 43 URL checks dropped the test execution time down from ~7.5-11 seconds per run to just over 2.5 seconds.