### PR TITLE
Fix JDK17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,18 +11,11 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.continue-on-error }}
 
     strategy:
-      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-10.15, windows-latest]
-        java-version: [ '8', '11' ]
-        continue-on-error: [false]
-        include:
-          - os: ubuntu-latest
-            java-version: '17'
-            continue-on-error: true
+        java-version: [ '8', '11', '17' ]
 
     steps:
     - uses: actions/checkout@v3

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -98,6 +98,48 @@
 				</plugins>
 			</build>
 		</profile>
+		<profile>
+			<id>java-17</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+				<jdk>[17,)</jdk>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+					 <groupId>com.coderplus.maven.plugins</groupId>
+				   <artifactId>copy-rename-maven-plugin</artifactId>
+						<executions>
+						  <execution>
+							 <id>rename-file</id>
+						   <phase>generate-sources</phase>
+						   <goals>
+							  <goal>copy</goal>
+							 </goals>
+							 <configuration>
+								 <fileSets>
+									 <fileSet>
+										 <sourceFile>src/com/biglybt/internat/MessagesBundle_iw_IL.properties</sourceFile>
+										 <destinationFile>${project.build.directory}/classes/com/biglybt/internat/MessagesBundle_he_IL.properties</destinationFile>
+									 </fileSet>
+									 <fileSet>
+										 <sourceFile>src/com/biglybt/internat/MessagesBundle_in_ID.properties</sourceFile>
+										 <destinationFile>${project.build.directory}/classes/com/biglybt/internat/MessagesBundle_id_ID.properties</destinationFile>
+									 </fileSet>
+									 <!-- No current translations exist for this code
+									 <fileSet>
+										 <sourceFile>src/com/biglybt/internat/MessagesBundle_ji_??.properties</sourceFile>
+										 <destinationFile>${project.build.directory}/classes/com/biglybt/internat/MessagesBundle_yi_??.properties</destinationFile>
+										 </fileSet>
+									 -->
+								 </fileSets>
+							 </configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,11 @@
 					<artifactId>maven-surefire-plugin</artifactId>
 					<version>2.22.2</version>
 				</plugin>
+				<plugin>
+					<groupId>com.coderplus.maven.plugins</groupId>
+					<artifactId>copy-rename-maven-plugin</artifactId>
+					<version>1.0.1</version>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 		<plugins>


### PR DESCRIPTION
This PR  uses the copy/rename Maven plugin to copy two translation files to their updated names, when building under JDK17+. This allows the tests to pass.

Now that JDK17 builds are successful, run them on all three platforms in CI, same as other versions.