### PR TITLE
CI: Switch to macos-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-10.15, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         java-version: [ '8', '11', '17' ]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,6 @@ jobs:
         java-version: ${{ matrix.java-version }}
         distribution: 'temurin'
         cache: maven
-    - name: Build with Maven
-      id: maven_compile
-      run: mvn compile --file pom.xml
     - name: Package with Maven
       id: maven_package
       run: mvn package --file pom.xml


### PR DESCRIPTION
GitHub has started browning out `macos-10.15`, as it's going away at the end of August.