### PR TITLE
ProgressETA: Avoid NPEs with FakeTableCell

### DIFF
--- a/uis/src/com/biglybt/ui/swt/columns/torrent/ColumnProgressETA.java
+++ b/uis/src/com/biglybt/ui/swt/columns/torrent/ColumnProgressETA.java
@@ -483,7 +483,6 @@ public class ColumnProgressETA
 			return;
 		}
 
-		int lineHeight = cell.getTableRow().getView().getLineHeight();
 		final boolean showSecondLine;
 		int alignSecondLine;
 		Color fgSecondLine;
@@ -493,6 +492,14 @@ public class ColumnProgressETA
 
 		boundsProgressBar.width--;	// adjust as includes pixel for column line :(
 		
+		final int lineCount = cell.getMaxLines();
+		int lineHeight;
+		if ( lineCount > 1 ) {
+			lineHeight = cell.getTableRow().getView().getLineHeight();
+		} else {
+			lineHeight = cellBounds.height;
+		}
+
 		if (cellBounds.height >= Math.min( minTwoLineHeight, lineHeight*2 )) {
 			showSecondLine = true;
 			boundsProgressBar.height -= secondLineHeight;


### PR DESCRIPTION
I noticed storms of these in my debug log earlier:

```text
[04:39:21] [stderr]   java.lang.NullPointerException
        at com.biglybt.ui.swt.columns.torrent.ColumnProgressETA.cellPaint(ColumnProgressETA.java:486)
        at com.biglybt.ui.swt.views.table.impl.FakeTableCell.invokeSWTPaintListeners(FakeTableCell.java:370)
        at com.biglybt.ui.swt.views.table.impl.FakeTableCell.doPaint(FakeTableCell.java:1092)
        at com.biglybt.ui.swt.views.table.impl.FakeTableCell.paintControl(FakeTableCell.java:1166)
        at org.eclipse.swt.widgets.TypedListener.handleEvent(TypedListener.java:234)
        at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:89)
        at org.eclipse.swt.widgets.Display.sendEvent(Display.java:5810)
        at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1529)
        at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1555)
        at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1538)
        at org.eclipse.swt.widgets.Control.gtk_draw(Control.java:3891)
        at org.eclipse.swt.widgets.Scrollable.gtk_draw(Scrollable.java:365)
        at org.eclipse.swt.widgets.Composite.gtk_draw(Composite.java:496)
        at org.eclipse.swt.widgets.Widget.windowProc(Widget.java:2482)
        at org.eclipse.swt.widgets.Control.windowProc(Control.java:6834)
        at org.eclipse.swt.widgets.Display.windowProc(Display.java:6118)
        at org.eclipse.swt.internal.gtk3.GTK3.gtk_main_do_event(Native Method)
        at org.eclipse.swt.widgets.Display.eventProc(Display.java:1552)
        at org.eclipse.swt.internal.gtk3.GTK3.gtk_main_iteration_do(Native Method)
        at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:4469)
        at com.biglybt.ui.swt.mainwindow.SWTThread.<init>(SWTThread.java:438)
```

`FakeTableCell` constructs a stub `TableRow` in response to `.getTableRow()`, and that object's `.getView()` returns `null`. So, it can't be dereffed unilaterally.

`FakeTableCell` also returns `-1` in response to `.getMaxLines()`, tho, so sequestering the `.getLineHeight()` lookup behind a test for `.getMaxLines() > 1` avoids the `lineHeight` lookup via `getView().getLineHeight()`, and thus the NPE.