### PR TITLE
IpFilter: Tweak logging

### DIFF
--- a/core/src/com/biglybt/core/ipfilter/impl/IpFilterImpl.java
+++ b/core/src/com/biglybt/core/ipfilter/impl/IpFilterImpl.java
@@ -491,7 +491,7 @@ IpFilterImpl
 	      if ( addBlockedIP( new BlockedIpImpl( ipAddress, match, torrent_name, loggable), torrent_hash, loggable )){
 
 		      if (Logger.isEnabled())
-						Logger.log(new LogEvent(LOGID_NWMAN, LogEvent.LT_WARNING, "Ip Blocked : "
+						Logger.log(new LogEvent(LOGID_NWMAN, "Ip Blocked : "
 								+ ipAddress + ", in range : " + match));
 
 		      return true;
@@ -520,7 +520,7 @@ IpFilterImpl
 	    if ( addBlockedIP( new BlockedIpImpl(ipAddress,null, torrent_name, loggable), torrent_hash, loggable )){
 
 		    if (Logger.isEnabled())
-					Logger.log(new LogEvent(LOGID_NWMAN, LogEvent.LT_WARNING, "Ip Blocked : "
+					Logger.log(new LogEvent(LOGID_NWMAN, "Ip Blocked : "
 							+ ipAddress + ", not in any range"));
 
 		    return true;
@@ -620,7 +620,7 @@ IpFilterImpl
 	      if ( addBlockedIP( new BlockedIpImpl(ipAddress.getHostAddress(),match, torrent_name, loggable), torrent_hash, loggable )){
 
 		      if (Logger.isEnabled())
-						Logger.log(new LogEvent(LOGID_NWMAN, LogEvent.LT_WARNING, "Ip Blocked : "
+						Logger.log(new LogEvent(LOGID_NWMAN, "Ip Blocked : "
 								+ ipAddress + ", in range : " + match));
 
 		      return true;
@@ -645,7 +645,7 @@ IpFilterImpl
 	    if ( addBlockedIP( new BlockedIpImpl(ipAddress.getHostAddress(),null, torrent_name, loggable), torrent_hash, loggable )){
 
 		    if (Logger.isEnabled())
-					Logger.log(new LogEvent(LOGID_NWMAN, LogEvent.LT_WARNING, "Ip Blocked : "
+					Logger.log(new LogEvent(LOGID_NWMAN, "Ip Blocked : "
 							+ ipAddress + ", not in any range"));
 
 		    return true;

--- a/core/src/com/biglybt/core/ipfilter/impl/IpFilterImpl.java
+++ b/core/src/com/biglybt/core/ipfilter/impl/IpFilterImpl.java
@@ -48,6 +48,7 @@ IpFilterImpl
 	implements IpFilter
 {
 	protected static final LogIDs LOGID = LogIDs.CORE;
+	protected static final LogIDs LOGID_NWMAN = LogIDs.NWMAN;
 
 	private final static int MAX_BLOCKS_TO_REMEMBER = 500;
 
@@ -490,7 +491,7 @@ IpFilterImpl
 	      if ( addBlockedIP( new BlockedIpImpl( ipAddress, match, torrent_name, loggable), torrent_hash, loggable )){
 
 		      if (Logger.isEnabled())
-						Logger.log(new LogEvent(LOGID, LogEvent.LT_WARNING, "Ip Blocked : "
+						Logger.log(new LogEvent(LOGID_NWMAN, LogEvent.LT_WARNING, "Ip Blocked : "
 								+ ipAddress + ", in range : " + match));
 
 		      return true;
@@ -498,7 +499,7 @@ IpFilterImpl
 	      }else{
 
 		      if (Logger.isEnabled())
-					Logger.log(new LogEvent(LOGID, LogEvent.LT_WARNING, "Ip Blocking Denied : "
+					Logger.log(new LogEvent(LOGID_NWMAN, LogEvent.LT_WARNING, "Ip Blocking Denied : "
 							+ ipAddress + ", in range : " + match));
 
 		      return false;
@@ -519,7 +520,7 @@ IpFilterImpl
 	    if ( addBlockedIP( new BlockedIpImpl(ipAddress,null, torrent_name, loggable), torrent_hash, loggable )){
 
 		    if (Logger.isEnabled())
-					Logger.log(new LogEvent(LOGID, LogEvent.LT_WARNING, "Ip Blocked : "
+					Logger.log(new LogEvent(LOGID_NWMAN, LogEvent.LT_WARNING, "Ip Blocked : "
 							+ ipAddress + ", not in any range"));
 
 		    return true;
@@ -527,7 +528,7 @@ IpFilterImpl
 	    }else{
 
 		    if (Logger.isEnabled())
-				Logger.log(new LogEvent(LOGID, LogEvent.LT_WARNING, "Ip Blocking Denied : "
+				Logger.log(new LogEvent(LOGID_NWMAN, LogEvent.LT_WARNING, "Ip Blocking Denied : "
 						+ ipAddress + ", not in any range"));
 
 		    return false;
@@ -619,7 +620,7 @@ IpFilterImpl
 	      if ( addBlockedIP( new BlockedIpImpl(ipAddress.getHostAddress(),match, torrent_name, loggable), torrent_hash, loggable )){
 
 		      if (Logger.isEnabled())
-						Logger.log(new LogEvent(LOGID, LogEvent.LT_WARNING, "Ip Blocked : "
+						Logger.log(new LogEvent(LOGID_NWMAN, LogEvent.LT_WARNING, "Ip Blocked : "
 								+ ipAddress + ", in range : " + match));
 
 		      return true;
@@ -627,7 +628,7 @@ IpFilterImpl
 	      }else{
 
 		      if (Logger.isEnabled())
-						Logger.log(new LogEvent(LOGID, LogEvent.LT_WARNING, "Ip Blocking Denied: "
+						Logger.log(new LogEvent(LOGID_NWMAN, LogEvent.LT_WARNING, "Ip Blocking Denied: "
 								+ ipAddress + ", in range : " + match));
 
 		      return false;
@@ -644,14 +645,14 @@ IpFilterImpl
 	    if ( addBlockedIP( new BlockedIpImpl(ipAddress.getHostAddress(),null, torrent_name, loggable), torrent_hash, loggable )){
 
 		    if (Logger.isEnabled())
-					Logger.log(new LogEvent(LOGID, LogEvent.LT_WARNING, "Ip Blocked : "
+					Logger.log(new LogEvent(LOGID_NWMAN, LogEvent.LT_WARNING, "Ip Blocked : "
 							+ ipAddress + ", not in any range"));
 
 		    return true;
 	    }else{
 
 		    if (Logger.isEnabled())
-				Logger.log(new LogEvent(LOGID, LogEvent.LT_WARNING, "Ip Blocking Denied : "
+				Logger.log(new LogEvent(LOGID_NWMAN, LogEvent.LT_WARNING, "Ip Blocking Denied : "
 						+ ipAddress + ", not in any range"));
 
 		    return false;


### PR DESCRIPTION
This PR consists of two commits which make minor/housekeeping changes to the logging in the IpFilter implementation:

1. Split up IPFilter LogIDs
    - All filter-list management will still be logged to `LogIDs.CORE`. `CORE` is still the default `IpFilterImpl.LOGID`.
    - Individual IP block activity will be logged to `LogIDs.NWMAN`, instead.
2. Lower block success logs to INFO

It never made sense to me, that the logs for blocked IPs were in the "core" logging stream, while everything else to do with connection setup and teardown was logged as "nwman". So, the first commit moves _only_ the logs for blocked-IP additions to "nwman", while leaving the logging for management of filter lists in the "core" stream.

It also never made sense to me that successful blocks (a perfectly normal course-of-operations event, when a filter list is defined) were being logged at the "WARNING" level. There's nothing abnormal or actionable about a successfully-blocked IP, so for the log message to be calling attention to itself is just distracting.