### PR TITLE
Shorten default smoothing window to 20s (min 10s)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.biglybt</groupId>
 		<artifactId>biglybt-parent</artifactId>
-		<version>3.1.0.1-SNAPSHOT</version>
+		<version>3.4.0.1-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/core/src/com/biglybt/core/global/GlobalManagerStats.java
+++ b/core/src/com/biglybt/core/global/GlobalManagerStats.java
@@ -61,12 +61,12 @@ GlobalManagerStats
 
 	/**
 	 * Smoothed Send Rate, including data and protocol, based on
-	 * "Stats Smoothing Secs" (default to 60s, min 30s)
+	 * "Stats Smoothing Secs" (default to 20s, min 10s)
 	 */
 	public long	getSmoothedSendRate();
 	/**
 	 * Smoothed Receive Rate, including data and protocol, based on
-	 * "Stats Smoothing Secs" (default to 60s, min 30s)
+	 * "Stats Smoothing Secs" (default to 20s, min 10s)
 	 */
 	public long	getSmoothedReceiveRate();
 

--- a/core/src/com/biglybt/core/global/GlobalManagerStats.java
+++ b/core/src/com/biglybt/core/global/GlobalManagerStats.java
@@ -24,7 +24,6 @@ import java.net.InetAddress;
 import java.util.*;
 
 import com.biglybt.core.download.DownloadManager;
-import com.biglybt.core.util.CopyOnWriteList;
 
 /**
  * @author parg

--- a/core/src/com/biglybt/core/util/GeneralUtils.java
+++ b/core/src/com/biglybt/core/util/GeneralUtils.java
@@ -263,7 +263,7 @@ GeneralUtils
 		return s;
 	}
 
-	private static int SMOOTHING_UPDATE_WINDOW	 	= 60;
+	private static int SMOOTHING_UPDATE_WINDOW	 	= 20;
 	private static int SMOOTHING_UPDATE_INTERVAL 	= 1;
 
 
@@ -279,9 +279,9 @@ GeneralUtils
 				{
 					SMOOTHING_UPDATE_WINDOW	= COConfigurationManager.getIntParameter( "Stats Smoothing Secs" );
 
-					if ( SMOOTHING_UPDATE_WINDOW < 30 ){
+					if ( SMOOTHING_UPDATE_WINDOW < 10 ){
 
-						SMOOTHING_UPDATE_WINDOW = 30;
+						SMOOTHING_UPDATE_WINDOW = 10;
 
 					}else if ( SMOOTHING_UPDATE_WINDOW > 30*60 ){
 

--- a/core/src/com/biglybt/ui/config/ConfigSectionStats.java
+++ b/core/src/com/biglybt/ui/config/ConfigSectionStats.java
@@ -91,7 +91,7 @@ public class ConfigSectionStats
 		// general
 
 		IntParameterImpl paramStatsSmoothingSecs = new IntParameterImpl(
-				ICFG_STATS_SMOOTHING_SECS, "stats.general.smooth_secs", 30, 30 * 60);
+				ICFG_STATS_SMOOTHING_SECS, "stats.general.smooth_secs", 10, 30 * 60);
 		add(paramStatsSmoothingSecs);
 
 		add("pgGeneralStats", new ParameterGroupImpl("ConfigView.section.general",

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.biglybt</groupId>
 	<artifactId>biglybt-parent</artifactId>
-	<version>3.1.0.1-SNAPSHOT</version>
+	<version>3.4.0.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>BiglyBT - Parent</name>
 

--- a/uis/pom.xml
+++ b/uis/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.biglybt</groupId>
         <artifactId>biglybt-parent</artifactId>
-        <version>3.1.0.1-SNAPSHOT</version>
+        <version>3.4.0.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>


### PR DESCRIPTION
This PR (in three separate commits)

1. Changes the configuration for smoothing window, by:
    - Reducing the default `SMOOTHING_UPDATE_WINDOW` to `20`, down from `60`
    - Reducing the _minimum_ value to `10`, down from `30`
    - (Leaving the maximum value at `30 * 60`)

2. Removes an unused import from `core/src/com/biglybt/core/global/GlobalManagerStats.java`

3. Updates the build version in the pom files to `3.4.0.1-SNAPSHOT`

#### Motivation

The current window values/constraints were arrived at many years ago, when speeds were much lower and swarms were much smaller. With modern broadband speeds and data rates, even a multi-gigabyte torrent might _complete_ downloading in under 60s, for many users.

When entire torrents download in a matter of seconds or single-digit minutes, because of the current 60s window the initial "ramp-up" time (when fewer peers are connected and data rates are suppressed) continues to bias the ETAs for far too much of the transfer, throwing off the completion estimates until the download is nearly complete.

Using a shorter window allows the ETA estimates to approach reality much more quickly, once the torrent "hits its stride" at maximum transfer rate.

#### Impact

**Note:** I'm not clear on which, but either _all_ existing users, or only existing users who've already customized the setting in **Options > Statistics > General > Smoothed average window size [secs]**, will be unaffected by this change unless they use that setting to reduce their window size, after installing a build of BiglyBT that includes these changes.