### PR TITLE
Issue template/config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: BiglyBT SubReddit
+    url: https://www.reddit.com/r/BiglyBT/
+    about: Please use Reddit for general discussion.

--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,3 +1,7 @@
+---
+name: Report a bug in BiglyBT
+about: Not for general discussion (See link to Reddit)
+---
 <!--
 Any posts or screenshots displaying torrent names, search results, subscription names, will be removed without notification, unless they are linux distros.
 For bugs, please include the "System" section of the Help->About window, or if you don't have access to the window, include: -->


### PR DESCRIPTION
- Add required front matter to issue template file
- Add config file providing Reddit link, and disabling blank issues

This should do it. The template file needed some required front matter, guess they dropped support for bare templates. The front matter now marks the template as the bug-reporting workflow.

I also added a config file for the issue selector that disables blank issue creation, and provides the Reddit link alongside the bug-report template. (So, the pinned issue is probably no longer necessary, @parg.)