### PR TITLE
Ensure JAVA_VERSION is set when JAVA_PROGRAM_DIR is defined

### DIFF
--- a/core/src/com/biglybt/platform/unix/startupScript
+++ b/core/src/com/biglybt/platform/unix/startupScript
@@ -175,6 +175,8 @@ if [ "$JAVA_PROGRAM_DIR" == "" ]; then
 	if ! look_for_java ; then
 		exit 1
 	fi
+else
+	check_version
 fi
 
 # Java 11+ needs --add-opens, which borks some older java versions


### PR DESCRIPTION
Always call look_for_java to set JAVA_VERSION    
    
This ensure that `--add-opens java.base/java.net=ALL-UNNAMED` is added to JAVA_ARGS for Java 11 or higher [1]    
    
Previously, when JAVA_PROGRAM_DIR was set, look_for_java was not called,    
and therefore JAVA_VERSION was not set.    
    
 [1]

     if echo "$JAVA_VERSION" | grep -E "^(1[1-9]|[2-9][0-9])\." > /dev/null ; then    
       JAVA_ARGS="${JAVA_ARGS} --add-opens java.base/java.net=ALL-UNNAMED"    
     fi 
