### PR TITLE
biglybt.desktop: do not specify Icon format

### DIFF
--- a/assets/linux/biglybt.desktop
+++ b/assets/linux/biglybt.desktop
@@ -3,7 +3,7 @@
 Name=BiglyBT
 GenericName=BitTorrent Client
 Exec=${installer:dir.main}/biglybt %U
-Icon=${installer:dir.main}/biglybt.svg
+Icon=${installer:dir.main}/biglybt
 Terminal=false
 Type=Application
 MimeType=x-scheme-handler/magnet;application/x-bittorrent;application/x-biglybt;x-scheme-handler/biglybt;


### PR DESCRIPTION
Forcing the SVG is not how it should be done:
https://specifications.freedesktop.org/icon-theme/latest/#icon_lookup