### PR TITLE
biglybt.desktop without placeholders

### DIFF
--- a/assets/linux/biglybt.desktop
+++ b/assets/linux/biglybt.desktop
@@ -1,12 +1,12 @@
-#!/usr/bin/env xdg-open
 [Desktop Entry]
 Name=BiglyBT
 GenericName=BitTorrent Client
 GenericName[ru]=Клиент сети БитТоррент
-Exec=${installer:dir.main}/biglybt %U
-Icon=${installer:dir.main}/biglybt
+Exec=biglybt %U
+Icon=biglybt
 Terminal=false
 Type=Application
 MimeType=x-scheme-handler/magnet;application/x-bittorrent;application/x-biglybt;x-scheme-handler/biglybt;
 Categories=Network;FileTransfer;P2P;GTK;Java;
+Keywords=file transfer;P2P
 StartupWMClass=BiglyBT


### PR DESCRIPTION
Essentially equivalent to running
sed -i -e '/^#!/d' -e 's|${installer:dir.main}/||' -e 's|\.svg||' -e 's/Application;//g' biglybt.desktop,
plus adding Keywords=file transfer;P2P;