### PR TITLE
Don't ask the shell for the icon of a directory that isn't there

### DIFF
--- a/uis/src/com/biglybt/ui/swt/ImageRepository.java
+++ b/uis/src/com/biglybt/ui/swt/ImageRepository.java
@@ -182,6 +182,12 @@ public class ImageRepository
 		boolean 			minifolder,
 		Consumer<PathIcon>	icon_listener ) 
 	{
+			// when nothing can be resolved we fall back to a stand-in; for a
+			// directory that has to be the folder icon, since callers can't tell
+			// the transparent one apart from a real answer and will cache it
+
+		String fallback_key = ( minifolder || ext.equals( "-folder" ))? "folder": "transparent";
+
 		Image image = null;
 
 		try {
@@ -203,6 +209,19 @@ public class ImageRepository
 						break;
 					}
 				}
+			}
+
+				// a directory that isn't there yet can't be asked about: the shell
+				// call sets SHGFI_USEFILEATTRIBUTES for a missing path and the
+				// attributes handed to it come from file.isDirectory(), which is
+				// false for something that doesn't exist. it then returns the
+				// icon for a plain file, and since folder icons are cached under
+				// one shared key that answer becomes the folder icon for every
+				// row until the client restarts.
+
+			if ( ext.equals( "-folder" ) && !file.exists()){
+
+				return( new PathIcon( ImageLoader.getInstance().getImage( "folder" )));
 			}
 
 			String ext_key = "osicon" + ext;
@@ -231,7 +250,7 @@ public class ImageRepository
 					
 				}else{
 					
-					default_image = ImageLoader.getInstance().getImage( minifolder ? "folder" : "transparent" );
+					default_image = ImageLoader.getInstance().getImage( fallback_key );
 				}
 				
 				if ( pfc != null ){
@@ -289,7 +308,7 @@ public class ImageRepository
 				
 				if ( pending_image == null ){
 					
-					pending_image = ImageLoader.getInstance().getImage( minifolder ? "folder" : "transparent" );
+					pending_image = ImageLoader.getInstance().getImage( fallback_key );
 				}
 
 				return( new PathIcon( pending_image, true ));
@@ -318,7 +337,7 @@ public class ImageRepository
 					
 					if ( ignore_icon_exts.contains( ext.toLowerCase( Locale.US  ))){
 						
-						return( new PathIcon( ImageLoader.getInstance().getImage(minifolder ? "folder" : "transparent")));
+						return( new PathIcon( ImageLoader.getInstance().getImage( fallback_key )));
 					}
 					
 					try {
@@ -396,7 +415,7 @@ public class ImageRepository
 		}
 
 		if (image == null) {
-			return( new PathIcon( ImageLoader.getInstance().getImage(minifolder ? "folder" : "transparent")));
+			return( new PathIcon( ImageLoader.getInstance().getImage( fallback_key )));
 		}
 		return( new PathIcon( image ));
 	}

--- a/uis/src/com/biglybt/ui/swt/utils/TorrentUIUtilsV3.java
+++ b/uis/src/com/biglybt/ui/swt/utils/TorrentUIUtilsV3.java
@@ -365,7 +365,7 @@ public class TorrentUIUtilsV3
 				
 				Image parent_image = imageLoaderThumb.imageAdded(id_parent_icon) ? imageLoaderThumb.getImage(id_parent_icon) : null;
 
-				if ( !parent_image.isDisposed()){
+				if ( parent_image != null && !parent_image.isDisposed()){
 					
 					existing_images = new Image[]{ existing_image, parent_image };
 				}


### PR DESCRIPTION
A torrent whose folder hasn't been created yet still gets its parent icon looked up, and the answer that comes back is the icon for a plain file - a blank sheet. Since folder icons are cached under one shared key, that answer becomes the folder icon for every row until the client is restarted.

The reason is in getFileIconSupport: a missing path sets SHGFI_USEFILEATTRIBUTES, so the shell doesn't look at the disk and goes by the attributes it was handed, and those come from

    file.isDirectory() ? 16 : FILE_ATTRIBUTE_NORMAL

which is false for something that doesn't exist. The call is asked about a normal file and answers accordingly.

Rather than reaching into the shell call, this skips it: a directory that isn't reachable is given the folder icon directly. The stand-in used when a lookup can't produce anything is a folder for directories too, for the same reason - callers can't tell the transparent image apart from a resolved icon and will happily cache it as the folder icon:

    if ( parentPathIcon == null || parentPathIcon.isDisposed()){ ... }
    else {
        images = new Image[]{ image, parentPathIcon };
        if ( !imageLoaderThumb.imageAdded(id_parent_icon)){
            imageLoaderThumb.addImageNoDipose(id_parent_icon, parentPathIcon );
        }
    }

Also adds the null check that path was missing: it reads the cached entry with a ternary that yields null and then dereferences it, which throws once the entry is absent rather than stale.

Noticed on a library of ~1300 torrents, where rows showed a blank sheet and no folder overlay while the files below them were fine. Reproduces on a clean master.