### PR TITLE
Don't record a busy icon lookup as "file has no icon"

### DIFF
--- a/uis/src/com/biglybt/ui/swt/ImageRepository.java
+++ b/uis/src/com/biglybt/ui/swt/ImageRepository.java
@@ -99,6 +99,12 @@ public class ImageRepository
 	private static final int	PFC_NONE	= 0;
 	private static final int	PFC_OK		= 1;
 	private static final int	PFC_TIMEOUT	= 2;
+
+		// a lookup that couldn't start because another was running. unlike a
+		// timeout this says nothing about the file being slow, so it is worth
+		// retrying almost immediately rather than after the timeout backoff.
+
+	private static final int	PFC_BUSY	= 3;
 	
 	
 	private static final Map<IconFileKey,PerFileContent>	per_file_content_keys =
@@ -475,6 +481,7 @@ public class ImageRepository
 
 					Image icon = null;
 					boolean	timeout = false;
+					boolean	busy	= false;
 					
 					if ( Constants.isWindows ){
 						try{
@@ -484,6 +491,7 @@ public class ImageRepository
 							if ( temp != null ){
 								icon = (Image)temp[0];
 								timeout = (Boolean)temp[1];
+								busy = temp.length > 2 && (Boolean)temp[2];
 							}
 						}catch( Throwable e ){
 						}
@@ -510,9 +518,32 @@ public class ImageRepository
 							result[0] = new PathIcon( default_icon, timeout );
 						}
 
+							// a timeout, or a lookup that couldn't run because
+							// another was in progress, says nothing about the
+							// file: record it as retryable. only a lookup that
+							// ran and came back empty means there is no icon.
+
 						synchronized( per_file_content_keys ){
 						
-							per_file_content_keys.put( file_key, new PerFileContent( PFC_NONE, null ));
+							int type = busy? PFC_BUSY: timeout? PFC_TIMEOUT: PFC_NONE;
+							
+							if ( type == PFC_NONE ){
+								
+								per_file_content_keys.put( file_key, new PerFileContent( PFC_NONE, null ));
+								
+							}else{
+								
+								PerFileContent pfc = per_file_content_keys.get( file_key );
+								
+								if ( pfc != null && pfc.type == type ){
+									
+									pfc.setFailed();
+									
+								}else{
+									
+									per_file_content_keys.put( file_key, new PerFileContent( type, null ));
+								}
+							}
 						}
 					}
 				}, false );
@@ -1227,7 +1258,10 @@ public class ImageRepository
 		final int		type;
 		final String	key;
 		
-		int		fail_count;
+			// written under the per_file_content_keys monitor but read by
+			// canRetry() outside it, so make the read see the current value
+
+		volatile int	fail_count;
 		
 		PerFileContent(
 			int		_type,
@@ -1236,7 +1270,7 @@ public class ImageRepository
 			type	= _type;
 			key		= _key;
 			
-			if ( type == PFC_TIMEOUT ){
+			if ( type == PFC_TIMEOUT || type == PFC_BUSY ){
 				
 				fail_count = 1;
 			}
@@ -1254,11 +1288,20 @@ public class ImageRepository
 		boolean
 		canRetry()
 		{
+			long elapsed = SystemTime.getMonotonousTime() - time;
+
 			if ( type == PFC_TIMEOUT ){
 				
-				long elapsed = SystemTime.getMonotonousTime() - time;
-				
 				long delay = fail_count * ( 30*1000 + RandomUtils.nextInt( 10*1000 ));
+				
+				return( elapsed > delay );
+				
+			}else if ( type == PFC_BUSY ){
+				
+					// the queue is serialised, so the next slot comes round
+					// quickly; back off a little if it keeps missing
+
+				long delay = Math.min( fail_count, 10 ) * ( 1000 + RandomUtils.nextInt( 500 ));
 				
 				return( elapsed > delay );
 				

--- a/uis/src/com/biglybt/ui/swt/win32/Win32UIEnhancer.java
+++ b/uis/src/com/biglybt/ui/swt/win32/Win32UIEnhancer.java
@@ -333,7 +333,12 @@ public class Win32UIEnhancer
 			
 			if ( gfi_active || gfi_consec_fails > 50 ){
 				
-				return( null );
+					// nothing is wrong with the file, we just can't look at it
+					// right now. the third element marks this as "busy" rather
+					// than a timeout, so the caller can come back promptly
+					// instead of recording the file as having no icon.
+				
+				return( new Object[]{ null, true, true });
 			}
 			
 			gfi_active = true;
@@ -394,7 +399,7 @@ public class Win32UIEnhancer
 				gfi_pending_images.remove( img );
 			}
 			
-			return( new Object[]{ img, !ok });
+			return( new Object[]{ img, !ok, false });
 		}
 	}
 	


### PR DESCRIPTION
getFileIcon returns null both when a lookup times out and when one is simply already in progress, and the caller can't tell them apart. The second case says nothing about the file, but it gets filed as PFC_NONE, which is never retried - so that row shows the generic icon for the rest of the session.

Since lookups are deliberately serialised, this happens constantly on a large list: every row painted while another lookup is running loses its icon permanently, and scrolling makes it worse because more rows arrive during the window. Restarting produces a different set of losers, which from the outside looks like icons gradually accumulating over successive runs. On a library of ~1300 torrents, one session's log showed 15 lookups turned away this way against 65 that completed.

The busy case is now reported separately and recorded as PFC_BUSY, retried after about a second - the queue is serialised, so the next slot comes round quickly and the 30s+ timeout backoff would be wrong here. A timeout still records PFC_TIMEOUT with its own backoff, and a lookup that ran and came back empty still records PFC_NONE.

One extra line: fail_count is now volatile. It's written under the per_file_content_keys monitor but canRetry() reads it outside, and this patch adds a second branch there, so it seemed worth making the read see the current value. Nothing else changes - at worst the old behaviour picked a retry interval one step out.