### PR TITLE
Don't report a resolved per-file icon as temporary

### DIFF
--- a/uis/src/com/biglybt/ui/swt/ImageRepository.java
+++ b/uis/src/com/biglybt/ui/swt/ImageRepository.java
@@ -246,7 +246,7 @@ public class ImageRepository
 	
 							if ( ImageLoader.isRealImage( image )){
 								
-								return( new PathIcon( image, pfc.type != PFC_TIMEOUT ));
+								return( new PathIcon( image, pfc.type == PFC_TIMEOUT ));
 							}
 						}
 


### PR DESCRIPTION
The PathIcon returned for a cached per-file icon is flagged temporary when the entry is *not* a timeout, which looks backwards: PFC_OK is the resolved icon and PFC_TIMEOUT is the one still standing in.

TorrentUIUtilsV3 only puts an icon in the thumbnail cache when it's told the icon is final, so with the test inverted nothing for those extensions ever got cached there. The main list went through the whole lookup on every repaint and dropped the result each time; the files view caches in the cell and doesn't consult the flag, so it behaved normally. That difference is what made it visible - icons appear in the files panel below while the list above stays generic.

From a run against ~1300 .exe torrents: 126 getContentImage calls, all with temporary=true and none cached, while 114 icons arrived through the listener with temporary=false.