### PR TITLE
Persist per-file icons across restarts

### DIFF
--- a/uis/src/com/biglybt/ui/swt/ImageRepository.java
+++ b/uis/src/com/biglybt/ui/swt/ImageRepository.java
@@ -53,6 +53,7 @@ import com.biglybt.core.util.HostNameToIPResolver;
 import com.biglybt.core.util.RandomUtils;
 import com.biglybt.core.util.SHA1Simple;
 import com.biglybt.core.util.StringInterner;
+import com.biglybt.core.util.SystemProperties;
 import com.biglybt.core.util.SystemTime;
 import com.biglybt.pif.peers.Peer;
 import com.biglybt.pif.utils.LocationProvider;
@@ -91,6 +92,198 @@ public class ImageRepository
 		// millions of path strings
 
 	private static final int	PER_FILE_CACHE_MAX = 1024;
+
+		// per-file icons survive a restart. the in-memory cache already
+		// collapses identical icons onto one content key, so the disk layout
+		// follows it: one file per *distinct* icon plus a small index mapping
+		// files onto them. a library of thousands of installers usually needs
+		// only a few dozen icon files.
+		//
+		// the index is keyed by a hash of the path rather than the path itself,
+		// so it stays compact and doesn't write user paths out in the clear.
+
+	private static final int	DISK_INDEX_MAX = 4096;
+
+	private static final File	disk_cache_dir =
+		FileUtil.newFile( SystemProperties.getUserPath(), "cache", "fileicons" );
+
+	private static final int	disk_image_format = Constants.isWindows ? SWT.IMAGE_ICO : SWT.IMAGE_PNG;
+	private static final String	disk_image_ext    = Constants.isWindows ? ".ico" : ".png";
+
+		// path hash -> "<content key> <modified> <length>"
+
+	private static Map<String,String>	disk_index;
+
+		// names present in the cache directory, so testing for an icon doesn't
+		// hit the filesystem; same approach ImageLoader takes for its own cache
+
+	private static Set<String>			disk_files;
+
+	private static volatile boolean		disk_index_dirty;
+
+		// the index is read on the background dispatcher: listing the directory
+		// and reading the file is disk work, and doing it inline would block the
+		// first paint. until it has been read, lookups simply miss and fall
+		// through to the shell, which is what would have happened anyway.
+
+	private static volatile boolean		disk_init_done;
+	private static boolean				disk_init_started;
+
+	private static final AsyncDispatcher	disk_dispatcher = new AsyncDispatcher( "FileIconDisk" );
+
+		// returns true once the on-disk index is available; kicks off the read
+		// the first time it is asked
+
+	private static boolean
+	ensureDiskCache()
+	{
+		if ( disk_init_done ){
+
+			return( true );
+		}
+
+		synchronized( ImageRepository.class ){
+
+			if ( disk_init_started ){
+
+				return( false );
+			}
+
+			disk_init_started = true;
+		}
+
+		disk_dispatcher.dispatch(()->{
+
+			synchronized( ImageRepository.class ){
+
+				initDiskCache();
+			}
+
+			disk_init_done = true;
+		});
+
+		return( false );
+	}
+
+		// caller must hold the ImageRepository.class monitor
+
+	private static void
+	initDiskCache()
+	{
+		if ( disk_index != null ){
+
+			return;
+		}
+
+		Set<String> names = new HashSet<>();
+
+		File[] files = disk_cache_dir.listFiles();
+
+		if ( files != null ){
+
+			for ( File f: files ){
+
+				names.add( f.getName());
+			}
+		}
+
+		disk_files = names;
+
+		Map<String,String> loaded =
+			new LinkedHashMap<String,String>( 128, 0.75f, true )
+			{
+				@Override
+				protected boolean
+				removeEldestEntry(
+					Map.Entry<String,String> eldest )
+				{
+					if ( size() > DISK_INDEX_MAX ){
+
+						disk_index_dirty = true;
+
+						return( true );
+					}
+
+					return( false );
+				}
+			};
+
+		try{
+			Map<String,Object> stored = FileUtil.readResilientFile( disk_cache_dir, "index", false );
+
+			Object entries = stored.get( "entries" );
+
+			if ( entries instanceof Map ){
+
+				for ( Map.Entry<?,?> e: ((Map<?,?>)entries).entrySet()){
+
+					Object v = e.getValue();
+
+					loaded.put(
+						String.valueOf( e.getKey()),
+						v instanceof byte[]? new String((byte[])v, Constants.UTF_8 ): String.valueOf( v ));
+				}
+			}
+		}catch( Throwable e ){
+
+				// a damaged index just means a cold cache
+		}
+
+		disk_index = loaded;
+
+			// entries age out of the index, but the icons they pointed at would
+			// otherwise sit in the directory forever; drop any that nothing
+			// refers to any more
+
+		Set<String> referenced = new HashSet<>();
+
+		for ( String entry: loaded.values()){
+
+			int pos = entry.indexOf( ' ' );
+
+			if ( pos > 0 ){
+
+				referenced.add( getDiskImageName( entry.substring( 0, pos )));
+			}
+		}
+
+		for ( String name: new java.util.ArrayList<>( names )){
+
+			if ( name.equals( "index" ) || name.startsWith( "index." )){
+
+				continue;
+			}
+
+			if ( !referenced.contains( name )){
+
+				if ( FileUtil.newFile( disk_cache_dir, name ).delete()){
+
+					names.remove( name );
+				}
+			}
+		}
+	}
+
+		// derived from the key itself rather than from separately passed flags,
+		// so the two can't drift apart
+
+	private static String
+	getDiskKey(
+		File			file,
+		IconFileKey		file_key )
+	{
+		String str = file.getAbsolutePath() + "-" + file_key.modifier;
+
+		return( ByteFormatter.encodeString( new SHA1Simple().calculateHash( str.getBytes( Constants.UTF_8 ))));
+	}
+
+	private static String
+	getDiskImageName(
+		String		content_key )
+	{
+		return( content_key.substring( content_key.indexOf( ':' ) + 1 ) + disk_image_ext );
+	}
+
 
 		// marks a file whose icon lookup came back empty, so a failure doesn't
 		// have every repaint queue the lookup again; the entry ages out of the
@@ -265,6 +458,16 @@ public class ImageRepository
 						scheduleAsyncIconFetch( file, file_key, bBig, minifolder, default_image, icon_listener );
 					}
 				}else{
+
+						// nothing in memory, but it may have been resolved in an
+						// earlier session
+
+					Image from_disk = getIconFromDisk( file, file_key );
+
+					if ( from_disk != null ){
+
+						return( new PathIcon( from_disk ));
+					}
 
 					scheduleAsyncIconFetch( file, file_key, bBig, minifolder, default_image, icon_listener );
 				}
@@ -441,6 +644,311 @@ public class ImageRepository
 		// resolve a per-file icon without blocking the interface: the (potentially
 		// slow) file existence check runs on a background thread, the icon lookup
 		// itself is then handed to the SWT thread as getFileIcon requires
+
+	private static void
+	saveDiskIndex()
+	{
+		synchronized( ImageRepository.class ){
+
+			disk_index_dirty = true;
+		}
+
+		disk_dispatcher.dispatch(()->{
+
+			Map<String,String>	copy;
+
+			synchronized( ImageRepository.class ){
+
+				if ( !disk_index_dirty || disk_index == null ){
+
+					return;
+				}
+
+				disk_index_dirty = false;
+
+				copy = new LinkedHashMap<>( disk_index );
+			}
+
+			try{
+				Map<String,Object>	entries = new HashMap<>();
+
+				for ( Map.Entry<String,String> e: copy.entrySet()){
+
+					entries.put( e.getKey(), e.getValue().getBytes( Constants.UTF_8 ));
+				}
+
+				Map<String,Object>	stored = new HashMap<>();
+
+				stored.put( "entries", entries );
+
+				disk_cache_dir.mkdirs();
+
+				FileUtil.writeResilientFile( disk_cache_dir, "index", stored, false );
+
+			}catch( Throwable e ){
+
+				Debug.out( e );
+			}
+		});
+	}
+
+		// hands back a cached icon if we have one for this file, and kicks off a
+		// background check that the file hasn't changed since it was stored.
+		// checking before returning would put the disk access we're avoiding
+		// straight back onto the UI thread.
+
+	private static Image
+	getIconFromDisk(
+		File			file,
+		IconFileKey		file_key )
+	{
+		try{
+			if ( !ensureDiskCache()){
+
+				return( null );
+			}
+
+			String		disk_key;
+			String		entry;
+
+			synchronized( ImageRepository.class ){
+
+				disk_key = getDiskKey( file, file_key );
+
+				entry = disk_index.get( disk_key );
+			}
+
+			if ( entry == null ){
+
+				return( null );
+			}
+
+			String[] bits = entry.split( " " );
+
+			if ( bits.length != 3 ){
+
+				return( null );
+			}
+
+			String content_key = bits[0];
+
+			Image image = ImageLoader.getInstance().getImage( content_key );
+
+			if ( !ImageLoader.isRealImage( image )){
+
+				ImageLoader.getInstance().releaseImage( content_key );
+
+				image = loadDiskImage( content_key );
+
+				if ( image == null ){
+
+					synchronized( ImageRepository.class ){
+
+						disk_index.remove( disk_key );
+					}
+
+					saveDiskIndex();
+
+					return( null );
+				}
+
+				ImageLoader.getInstance().addImageNoDipose( content_key, image );
+			}
+
+			synchronized( per_file_content_keys ){
+
+				per_file_content_keys.put( file_key, new PerFileContent( PFC_OK, content_key ));
+			}
+
+			scheduleDiskStaleCheck( file, file_key, disk_key, bits[1], bits[2] );
+
+			return( image );
+
+		}catch( Throwable e ){
+
+			return( null );
+		}
+	}
+
+		// this does read a file on the SWT thread, which is deliberate: the
+		// point of the cache is to hand the icon back synchronously, and it is
+		// a few KB from our own directory on the local disk. the shell call it
+		// replaces is the one that can block for seconds on a dead share.
+
+	private static Image
+	loadDiskImage(
+		String		content_key )
+	{
+		String name = getDiskImageName( content_key );
+
+		synchronized( ImageRepository.class ){
+
+			if ( !disk_files.contains( name )){
+
+				return( null );
+			}
+		}
+
+		File file = FileUtil.newFile( disk_cache_dir, name );
+
+		InputStream is = null;
+
+		try{
+			is = FileUtil.newFileInputStream( file );
+
+			return( new Image( Display.getDefault(), is ));
+
+		}catch( Throwable e ){
+
+				// truncated or corrupt, treat as a miss and let it be written again
+
+			file.delete();
+
+			synchronized( ImageRepository.class ){
+
+				disk_files.remove( name );
+			}
+
+			return( null );
+
+		}finally{
+
+			if ( is != null ){
+
+				try{ is.close(); }catch( Throwable f ){}
+			}
+		}
+	}
+
+		// called on the SWT thread, so the only thing done here is pulling the
+		// pixels out of the Image - an SWT operation that has to happen on this
+		// thread. serialising them, writing the file and stat'ing the source all
+		// go to the background dispatcher, since none of it belongs on the UI
+		// thread.
+
+	private static void
+	storeIconOnDisk(
+		File			file,
+		IconFileKey		file_key,
+		String			content_key,
+		Image			icon )
+	{
+		final String	name = getDiskImageName( content_key );
+
+			// kick the index read off if it hasn't run yet. the dispatcher is
+			// sequential, so the work queued below lands after it and nothing
+			// is lost while the cache is warming up.
+
+		ensureDiskCache();
+
+		final ImageData data;
+
+		try{
+			data = icon.getImageData();
+
+		}catch( Throwable e ){
+
+			return;
+		}
+
+		disk_dispatcher.dispatch(()->{
+
+			boolean have_image;
+
+			synchronized( ImageRepository.class ){
+
+				if ( disk_index == null ){
+
+					return;
+				}
+
+				have_image = disk_files.contains( name );
+			}
+
+			if ( !have_image ){
+
+				try{
+					org.eclipse.swt.graphics.ImageLoader saver = new org.eclipse.swt.graphics.ImageLoader();
+
+					saver.data = new ImageData[]{ data };
+
+					ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+					saver.save( baos, disk_image_format );
+
+					disk_cache_dir.mkdirs();
+
+					FileUtil.writeBytesAsFile( FileUtil.newFile( disk_cache_dir, name ).getAbsolutePath(), baos.toByteArray());
+
+					synchronized( ImageRepository.class ){
+
+						disk_files.add( name );
+					}
+				}catch( Throwable e ){
+
+						// failing to persist isn't fatal, the memory cache still works
+
+					return;
+				}
+			}
+
+			try{
+				String disk_key = getDiskKey( file, file_key );
+
+				String entry = content_key + " " + file.lastModified() + " " + file.length();
+
+				synchronized( ImageRepository.class ){
+
+					disk_index.put( disk_key, entry );
+				}
+
+				saveDiskIndex();
+
+			}catch( Throwable e ){
+			}
+		});
+	}
+
+	private static void
+	scheduleDiskStaleCheck(
+		File			file,
+		IconFileKey		file_key,
+		String			disk_key,
+		String			modified,
+		String			length )
+	{
+		disk_dispatcher.dispatch(()->{
+
+			try{
+				if ( !Utils.fileExistsWithTimeout( file )){
+
+					return;
+				}
+
+				if ( 	String.valueOf( file.lastModified()).equals( modified ) &&
+						String.valueOf( file.length()).equals( length )){
+
+					return;
+				}
+
+					// the file has been replaced since the icon was stored
+
+				synchronized( ImageRepository.class ){
+
+					disk_index.remove( disk_key );
+				}
+
+				synchronized( per_file_content_keys ){
+
+					per_file_content_keys.remove( file_key );
+				}
+
+				saveDiskIndex();
+
+			}catch( Throwable e ){
+			}
+		});
+	}
 
 	private static void
 	scheduleAsyncIconFetch(
@@ -664,6 +1172,8 @@ public class ImageRepository
 					per_file_content_keys.put( file_key, pfc );
 				}
 
+				storeIconOnDisk( file, file_key, content_key, existing );
+
 				return( existing );
 			}
 
@@ -678,6 +1188,8 @@ public class ImageRepository
 			
 				per_file_content_keys.put( file_key, new PerFileContent( PFC_OK, content_key ));
 			}
+			
+			storeIconOnDisk( file, file_key, content_key, icon );
 			
 			return( icon );
 			


### PR DESCRIPTION
Per-file icons are resolved one at a time through the shell, so on a large library they trickle in for a while after every start. Keeping them on disk makes everything seen before a synchronous hit.

The in-memory cache already collapses identical icons onto one content key, and the disk layout follows it: one file per *distinct* icon in cache/fileicons, plus a small index mapping files onto them. A library of thousands of installers typically needs only a few dozen icon files - on mine it's 60 files for 1300 torrents.

- the index is keyed by a hash of the path rather than the path itself, so it stays compact and doesn't write user paths out in the clear. it's bounded at 4096 entries (LRU) and written through an AsyncDispatcher
- the directory listing is read once into a set, so testing whether an icon is present doesn't hit the filesystem - the same approach ImageLoader takes for its own cache directory
- the index read itself happens on the dispatcher too; until it's done, lookups just miss and fall through to the shell, which is what would have happened anyway
- a cached icon is returned immediately and checked afterwards: comparing the recorded modification time and length happens in the background, since doing it up front would put the disk access this is meant to avoid back on the UI thread
- entries age out of the index, so icons nothing refers to any more are deleted when the index is read, otherwise the directory would grow without limit
- a truncated or corrupt icon file is treated as a miss and deleted; a damaged index just means a cold cache
- ICO on Windows, PNG elsewhere

The only thing left on the SWT thread is reading a cached icon file, which is deliberate - the point is to hand it back synchronously, and it's a few KB from our own directory on the local disk rather than a shell call that can block for seconds on a dead share.

Given the threading review on #3762 I went over this specifically for that, then ran it through a set of scenario tests: cold and warm start, source file replaced or removed, corrupt icon, corrupt index, orphan collection, index bound under 5000 inserts, and eight threads running concurrently. Two worth calling out:

- opening the client before an external drive is plugged in. Three sessions with the drive offline leave the index and the icons untouched, and everything is served from cache when it comes back. A file that genuinely changed while it was away is still dropped.
- a different volume appearing on the same drive letter. A path now holding a different file is detected and dropped; paths holding nothing are left alone, since "gone" can't be told apart from "drive not responding".

Known limit: a replacement with byte-identical length and timestamp isn't detected. Hashing contents on every paint would cost exactly the I/O this avoids, and length+mtime is the same bargain the rest of the client makes.

The four small fixes you merged this morning came out of testing this - without them the cache is there but most rows never reach it.