### PR TITLE
Re-resolve per-file icons once a download completes

### DIFF
--- a/uis/src/com/biglybt/ui/swt/ImageRepository.java
+++ b/uis/src/com/biglybt/ui/swt/ImageRepository.java
@@ -392,11 +392,29 @@ public class ImageRepository
 		boolean 			minifolder,
 		Consumer<PathIcon>	icon_listener ) 
 	{
+		return( getIconFromExtension( file, ext, bBig, minifolder, true, icon_listener ));
+	}
+	
+	public static PathIcon 
+	getIconFromExtension(
+		File				file, 
+		String				ext, 
+		boolean				bBig,
+		boolean 			minifolder,
+		boolean				file_complete,
+		Consumer<PathIcon>	icon_listener ) 
+	{
 			// when nothing can be resolved we fall back to a stand-in; for a
 			// directory that has to be the folder icon, since callers can't tell
 			// the transparent one apart from a real answer and will cache it
 
 		String fallback_key = ( minifolder || ext.equals( "-folder" ))? "folder": "transparent";
+
+			// the folder image is a real answer for a directory; the transparent
+			// one only means we couldn't get an icon this time round, so mark it
+			// temporary and callers won't cache it as though it were resolved
+
+		boolean fallback_is_placeholder = fallback_key.equals( "transparent" );
 
 		Image image = null;
 
@@ -428,7 +446,7 @@ public class ImageRepository
 
 			if ( per_file_icon ){
 
-				IconFileKey file_key = new IconFileKey( file, bBig, minifolder );
+				IconFileKey file_key = new IconFileKey( file, bBig, minifolder, file_complete );
 
 				PerFileContent pfc;
 				
@@ -473,7 +491,7 @@ public class ImageRepository
 						// nothing in memory, but it may have been resolved in an
 						// earlier session
 
-					Image from_disk = getIconFromDisk( file, file_key );
+					Image from_disk = file_complete? getIconFromDisk( file, file_key ): null;
 					
 					if ( from_disk != null ){
 
@@ -559,7 +577,7 @@ public class ImageRepository
 					
 					if ( ignore_icon_exts.contains( ext.toLowerCase( Locale.US  ))){
 						
-						return( new PathIcon( ImageLoader.getInstance().getImage( fallback_key )));
+						return( new PathIcon( ImageLoader.getInstance().getImage( fallback_key ), fallback_is_placeholder ));
 					}
 					
 					try {
@@ -647,7 +665,7 @@ public class ImageRepository
 				return( new PathIcon( ImageLoader.getInstance().getImage( "folder" )));
 			}
 
-			return( new PathIcon( ImageLoader.getInstance().getImage( fallback_key )));
+			return( new PathIcon( ImageLoader.getInstance().getImage( fallback_key ), fallback_is_placeholder ));
 		}
 		return( new PathIcon( image ));
 	}
@@ -1079,8 +1097,16 @@ public class ImageRepository
 							
 							if ( type == PFC_NONE ){
 								
-								per_file_content_keys.put( file_key, new PerFileContent( PFC_NONE, null ));
+								PerFileContent pfc = per_file_content_keys.get( file_key );
 								
+								if ( pfc != null && pfc.type == PFC_NONE ){
+									
+									pfc.setFailed();
+									
+								}else{
+									
+									per_file_content_keys.put( file_key, new PerFileContent( PFC_NONE, null ));
+								}
 							}else{
 								
 								PerFileContent pfc = per_file_content_keys.get( file_key );
@@ -1183,7 +1209,10 @@ public class ImageRepository
 					per_file_content_keys.put( file_key, pfc );
 				}
 
-				storeIconOnDisk( file, file_key, content_key, existing );
+				if ( file_key.isFileComplete()){
+
+					storeIconOnDisk( file, file_key, content_key, existing );
+				}
 
 				return( existing );
 			}
@@ -1200,7 +1229,10 @@ public class ImageRepository
 				per_file_content_keys.put( file_key, new PerFileContent( PFC_OK, content_key ));
 			}
 			
-			storeIconOnDisk( file, file_key, content_key, icon );
+			if ( file_key.isFileComplete()){
+
+				storeIconOnDisk( file, file_key, content_key, icon );
+			}
 			
 			return( icon );
 			
@@ -1288,6 +1320,24 @@ public class ImageRepository
 		boolean				minifolder,
 		Consumer<PathIcon>	icon_listener ) 
 	{
+		return( getPathIcon( path, isFile, bBig, minifolder, true, icon_listener ));
+	}
+	
+		// a file that is still being written has no embedded icon to read, so
+		// the shell hands back the generic one for the type. cached under the
+		// same key as the finished file that placeholder would stay put once
+		// the download completed, so the two are kept apart and the finished
+		// file simply misses the cache and resolves properly.
+	
+	public static PathIcon 
+	getPathIcon(
+		String				path, 
+		Boolean				isFile,
+		boolean				bBig,
+		boolean				minifolder,
+		boolean				file_complete,
+		Consumer<PathIcon>	icon_listener ) 
+	{
 		if (path == null){
 			return( new PathIcon( null ));
 		}
@@ -1328,7 +1378,7 @@ public class ImageRepository
 					key = ext;
 
 					if (noAWT)
-						return getIconFromExtension(file, ext, bBig, minifolder, icon_listener);
+						return getIconFromExtension(file, ext, bBig, minifolder, file_complete, icon_listener);
 
 					// case-insensitive file systems
 					for (int i = 0; i < noCacheExtList.length; i++) {
@@ -1426,7 +1476,7 @@ public class ImageRepository
 			return( new PathIcon( ImageLoader.getInstance().getImage("folder")));
 		}
 
-		return getIconFromExtension(file, ext, bBig, minifolder, icon_listener);
+		return getIconFromExtension(file, ext, bBig, minifolder, file_complete, icon_listener);
 	}
 
 	private static LocationProvider	flag_provider;
@@ -1775,6 +1825,15 @@ public class ImageRepository
 			boolean		big,
 			boolean		minifolder )
 		{
+			this( file, big, minifolder, true );
+		}
+		
+		IconFileKey(
+			File		file,
+			boolean		big,
+			boolean		minifolder,
+			boolean		file_complete )
+		{
 			file_key = new StringInterner.FileKey( file );
 			
 			short mod = 0;
@@ -1785,7 +1844,16 @@ public class ImageRepository
 			if ( minifolder ){
 				mod += 2;
 			}
+			if ( !file_complete ){
+				mod += 4;
+			}
 			modifier = (byte)mod;
+		}
+		
+		boolean
+		isFileComplete()
+		{
+			return(( modifier & 4 ) == 0 );
 		}
 		
 		public int
@@ -1824,7 +1892,7 @@ public class ImageRepository
 			type	= _type;
 			key		= _key;
 			
-			if ( type == PFC_TIMEOUT || type == PFC_BUSY ){
+			if ( type != PFC_OK ){
 				
 				fail_count = 1;
 			}
@@ -1856,6 +1924,20 @@ public class ImageRepository
 					// quickly; back off a little if it keeps missing
 
 				long delay = Math.min( fail_count, 10 ) * ( 1000 + RandomUtils.nextInt( 500 ));
+				
+				return( elapsed > delay );
+				
+			}else if ( type == PFC_NONE ){
+				
+					// the lookup ran and produced nothing, which usually means
+					// the file has no icon of its own. usually, but not always -
+					// the shell can come back empty for other reasons - and with
+					// no retry at all such a row keeps its stand-in for the whole
+					// session, with nothing able to replace it. retry, but widen
+					// the gap each time so a file that really has no icon isn't
+					// asked about forever.
+
+				long delay = Math.min( fail_count, 10 ) * ( 60*1000 + RandomUtils.nextInt( 15*1000 ));
 				
 				return( elapsed > delay );
 				

--- a/uis/src/com/biglybt/ui/swt/columns/torrent/ColumnThumbAndName.java
+++ b/uis/src/com/biglybt/ui/swt/columns/torrent/ColumnThumbAndName.java
@@ -330,8 +330,12 @@ public class ColumnThumbAndName
 					public void contentImageLoaded(Image image, boolean wasReturned) {
 						if (!wasReturned) {
 							// this may be triggered many times, so only invalidate and don't
-							// force a refresh()
+							// force a refresh(). redraw() is cheap enough to pair with it: it
+							// no-ops for a row that isn't visible and coalesces repeats, and
+							// without it a row that isn't otherwise changing waits for the
+							// next table refresh, which on an idle torrent is a long time
 							cell.invalidate();
+							cell.redraw();
 						}
 					}
 				});
@@ -468,11 +472,17 @@ public class ColumnThumbAndName
 					
 			Object piCache = cell.getData( KEY_PATH_ICON );
 		
+			boolean file_complete = fileInfo.getDownloaded() == fileInfo.getLength();
+			
 			if ( piCache != null ){
 				
 				Object[] temp = (Object[])piCache;
 				
-				if ( FileUtil.areFilePathsIdentical(((FileKey)temp[0]).getFile(),fileKey.getFile())){
+					// the icon a partial file resolves to isn't the one it will
+					// have once complete, so completion is part of the identity
+				
+				if ( 	FileUtil.areFilePathsIdentical(((FileKey)temp[0]).getFile(),fileKey.getFile()) &&
+						((Boolean)temp[2]) == file_complete ){
 					
 					imgThumbnail = (Image[])temp[1];
 				}
@@ -483,16 +493,25 @@ public class ColumnThumbAndName
 				ImageRepository.PathIcon pi =
 					ImageRepository.getPathIcon(
 						fileKey.getFile().getPath(), true, cellBounds.height >= 20, false,
+						file_complete,
 						(result)->{
 							if ( result != null ){
-								cell.setData( KEY_PATH_ICON, new Object[]{ fileKey, new Image[]{ result.image }});
+								cell.setData( KEY_PATH_ICON, new Object[]{ fileKey, new Image[]{ result.image }, file_complete });
 								cell.invalidate();
+								cell.redraw();
 							}
 						});
 				
 				imgThumbnail = new Image[]{ pi.image };
 				
-				cell.setData( KEY_PATH_ICON, new Object[]{ fileKey, imgThumbnail });
+					// a placeholder is what we get when the lookup couldn't run;
+					// caching it here would leave the row showing it until the
+					// cell is rebuilt, as nothing comes back to replace it
+
+				if ( !pi.temporary ){
+					
+					cell.setData( KEY_PATH_ICON, new Object[]{ fileKey, imgThumbnail, file_complete });
+				}
 			}
 		}
 

--- a/uis/src/com/biglybt/ui/swt/views/tableitems/files/NameItem.java
+++ b/uis/src/com/biglybt/ui/swt/views/tableitems/files/NameItem.java
@@ -403,11 +403,17 @@ public class NameItem extends CoreTableColumnSWT implements
 					
 			Object piCache = cell.getData( KEY_PATH_ICON );
 		
+			boolean file_complete = fileInfo.getDownloaded() == fileInfo.getLength();
+			
 			if ( piCache != null ){
 				
 				Object[] temp = (Object[])piCache;
 				
-				if ( FileUtil.areFilePathsIdentical(((FileKey)temp[0]).getFile(),fileKey.getFile() )){
+					// the icon a partial file resolves to isn't the one it will
+					// have once complete, so completion is part of the identity
+				
+				if ( 	FileUtil.areFilePathsIdentical(((FileKey)temp[0]).getFile(),fileKey.getFile()) &&
+						((Boolean)temp[2]) == file_complete ){
 					
 					imgThumbnail = (Image[])temp[1];
 				}
@@ -418,16 +424,25 @@ public class NameItem extends CoreTableColumnSWT implements
 				ImageRepository.PathIcon pi = 
 					ImageRepository.getPathIcon(
 						fileKey.getFile().getPath(), true, cell.getHeight() > 32, false,
+						file_complete,
 						(result)->{
 							if ( result != null ){
-								cell.setData( KEY_PATH_ICON, new Object[]{ fileKey, new Image[]{ result.image }});
+								cell.setData( KEY_PATH_ICON, new Object[]{ fileKey, new Image[]{ result.image }, file_complete });
 								cell.invalidate();
+								cell.redraw();
 							}
 						});
 				
 				imgThumbnail = new Image[]{ pi.image };
 		
-				cell.setData( KEY_PATH_ICON, new Object[]{ fileKey, imgThumbnail });
+					// a placeholder is what we get when the lookup couldn't run;
+					// caching it here would leave the row showing it until the
+					// cell is rebuilt, as nothing comes back to replace it
+
+				if ( !pi.temporary ){
+					
+					cell.setData( KEY_PATH_ICON, new Object[]{ fileKey, imgThumbnail, file_complete });
+				}
 			}
 		}
 

--- a/uis/src/com/biglybt/ui/swt/views/tableitems/mytorrents/NameItem.java
+++ b/uis/src/com/biglybt/ui/swt/views/tableitems/mytorrents/NameItem.java
@@ -165,6 +165,7 @@ public class NameItem extends CoreTableColumnSWT implements
 					ImageRepository.PathIcon pi = ImageRepository.getPathIcon(
 							fileInfo.getFile(true).getPath(), true, false, torrent != null
 									&& !torrent.isSimpleTorrent(),
+							fileInfo.getDownloaded() == fileInfo.getLength(),
 							(result)->{
 									// the icon arrived after this cell had already
 									// painted; the name hasn't changed so nothing


### PR DESCRIPTION
A file that's still being written has no embedded icon to read, so the shell hands back the generic one for the type. That placeholder was cached under the same key as the finished file, so it stayed in place after the download completed.

Rather than trying to recognise a generic icon, completion is part of the identity of what's cached: another bit in the IconFileKey modifier, alongside big and minifolder. An incomplete file gets its own entry and the finished file simply misses the cache and resolves properly - nothing has to detect anything.

- getPathIcon takes a file_complete flag; the existing signatures pass true, which is what they effectively assumed already
- an incomplete file is never written to the disk cache, since its icon is about to change
- the per-cell caches in ColumnThumbAndName and files/NameItem key on completion as well as path, otherwise they'd keep serving the placeholder after the entry below them had moved on

Four related fixes came out of testing this on a library of ~1300 torrents, all of them cases where a row keeps a stand-in it can't get rid of:

- the stand-in returned when a lookup can't produce anything is now flagged temporary. The transparent image was handed back through the single-argument PathIcon constructor, so callers took it for a resolved icon.
- the per-cell caches don't store a temporary icon. A row that asked while the shell was busy would otherwise keep showing the transparent stand-in until the cell was rebuilt, and for extensions that don't take the per-file path there's no listener to replace it.
- the listeners pair invalidate() with redraw(). invalidate() only sets FLAG_MUSTREFRESH, which the next table refresh consumes; a row whose torrent is idle may not be refreshed for many minutes, so the icon resolves but the row keeps the old one until something else disturbs it. redraw() is cheap enough to pair with it - it no-ops for rows that aren't visible and coalesces repeats - and it's how other columns already do this.
- PFC_NONE can be retried. It means the lookup ran and produced nothing, which usually means the file has no icon of its own - but not always, and with no retry at all the entry was final: no lookup scheduled, no listener registered, nothing able to replace the stand-in for the rest of the session. It now retries after about a minute, widening the gap each time so a file that really has no icon isn't asked about forever.

The first two show up when rechecking a batch of torrents at once: every row is invalidated together, they queue behind the serialised lookup, and the ones that miss their turn cache the stand-in, then stay blank until a restart. The third shows up on a single finished torrent - sitting on the row, the icon took about ten minutes to appear, and only after other rows were disturbed.