### PR TITLE
Key the pending icon cache by size as well as path

### DIFF
--- a/uis/src/com/biglybt/ui/swt/win32/Win32UIEnhancer.java
+++ b/uis/src/com/biglybt/ui/swt/win32/Win32UIEnhancer.java
@@ -323,13 +323,52 @@ public class Win32UIEnhancer
 	private static final long	GFI_RETRY_AFTER		= 30*1000;
 	private static AsyncDispatcher	gfi_dispatcher		= new AsyncDispatcher( "gfi" );
 	
-	private static final Map<FileKey,Object[]>	gfi_pending_images =
-			new LinkedHashMap<FileKey,Object[]>( 128, 0.75f, true )
+		// small and large icons for the same file are different images, so the
+		// size has to be part of the key - otherwise a lookup for one size is
+		// answered with whatever the other size cached
+
+	private static class
+	IconKey
+	{
+		final FileKey	file_key;
+		final boolean	big;
+
+		IconKey(
+			File		file,
+			boolean		_big )
+		{
+			file_key	= new FileKey( file );
+			big			= _big;
+		}
+
+		public int
+		hashCode()
+		{
+			return( file_key.hashCode() + ( big?1:0 ));
+		}
+
+		public boolean
+		equals(
+			Object		_other )
+		{
+			if ( !( _other instanceof IconKey )){
+
+				return( false );
+			}
+
+			IconKey other = (IconKey)_other;
+
+			return( other.big == big && other.file_key.equals( file_key ));
+		}
+	}
+
+	private static final Map<IconKey,Object[]>	gfi_pending_images =
+			new LinkedHashMap<IconKey,Object[]>( 128, 0.75f, true )
 			{
 				@Override
 				protected boolean
 				removeEldestEntry(
-					Map.Entry<FileKey,Object[]> eldest )
+					Map.Entry<IconKey,Object[]> eldest )
 				{
 					if ( size() > 64 ){
 						
@@ -392,7 +431,7 @@ public class Win32UIEnhancer
 			return( null );
 		}
 		
-		FileKey fk = new FileKey( file );
+		IconKey fk = new IconKey( file, big );
 		
 		synchronized( Win32UIEnhancer.class ){
 			


### PR DESCRIPTION
getFileIcon caches the result of a background lookup so a later call for the same file can pick it up, but the key is just the path:

    FileKey fk = new FileKey( file );

    Object[] existing = gfi_pending_images.remove( fk );

    if ( existing != null ){
        return( new Object[]{ existing[0], false, false });
    }

Small and large icons for a file are different images, and the two are asked for from different places - the files tree wants 16x16, the main list 32x32. Whichever asks first has its size cached under the path, and the other one gets that image back as though it were its own.

In practice the tree resolves first, so the main list ends up holding a 16x16 icon in a 32x32 slot. It looks like the icon never resolves: the row keeps a small generic-looking image while the same file in the tree below shows the right one, and nothing replaces it because as far as the caller is concerned the lookup succeeded.

Wrapping the path and the size in a small key fixes it. Spotted on a library of ~1300 torrents where rows in the main list stayed generic while the files view was correct.