### PR TITLE
Check a cached icon against its file once per session

### DIFF
--- a/uis/src/com/biglybt/ui/swt/ImageRepository.java
+++ b/uis/src/com/biglybt/ui/swt/ImageRepository.java
@@ -131,6 +131,24 @@ public class ImageRepository
 
 	private static final AsyncDispatcher	disk_dispatcher = new AsyncDispatcher( "FileIconDisk" );
 
+		// an entry only needs checking against the file once per session: the
+		// icon is served from the cache on every repaint, and stat'ing the file
+		// each time turns a scroll through a large library into thousands of
+		// filesystem hits
+
+	private static final Set<String>	disk_checked =
+		Collections.newSetFromMap(
+			new LinkedHashMap<String,Boolean>( 128, 0.75f, false )
+			{
+				@Override
+				protected boolean
+				removeEldestEntry(
+					Map.Entry<String,Boolean> eldest )
+				{
+					return( size() > DISK_INDEX_MAX );
+				}
+			});
+
 		// returns true once the on-disk index is available; kicks off the read
 		// the first time it is asked
 
@@ -756,6 +774,8 @@ public class ImageRepository
 					synchronized( ImageRepository.class ){
 
 						disk_index.remove( disk_key );
+					disk_checked.remove( disk_key );
+						disk_checked.remove( disk_key );
 					}
 
 					saveDiskIndex();
@@ -771,7 +791,17 @@ public class ImageRepository
 				per_file_content_keys.put( file_key, new PerFileContent( PFC_OK, content_key ));
 			}
 
-			scheduleDiskStaleCheck( file, file_key, disk_key, bits[1], bits[2] );
+			boolean check_needed;
+
+			synchronized( ImageRepository.class ){
+
+				check_needed = disk_checked.add( disk_key );
+			}
+
+			if ( check_needed ){
+
+				scheduleDiskStaleCheck( file, file_key, disk_key, bits[1], bits[2] );
+			}
 
 			return( image );
 


### PR DESCRIPTION
The staleness check runs on every cache hit: it compares the recorded modification time and length against the file, which is three filesystem calls, and the icon is served from the cache on every repaint.

Scrolling a large library back and forth turns that into thousands of calls for files nobody has touched. On a spinning disk it's enough to saturate it, since the reads are scattered across the whole library and are all seeks.

Remembering which entries have already been checked brings it down to one per file per session, which is what the check was for - an entry that was valid at startup doesn't become invalid because a row was repainted. Measured on a build instrumented to count the checks: 30 repaints of one row cost 30 checks before, 1 after.

The set is bounded like the index it shadows, and an entry dropped from the index is dropped from it too, so a file replaced later is still picked up on the next run.