### PR TITLE
Keep the timeout retry inside the pending-image window

### DIFF
--- a/uis/src/com/biglybt/ui/swt/ImageRepository.java
+++ b/uis/src/com/biglybt/ui/swt/ImageRepository.java
@@ -1846,7 +1846,15 @@ public class ImageRepository
 
 			if ( type == PFC_TIMEOUT ){
 				
-				long delay = fail_count * ( 30*1000 + RandomUtils.nextInt( 10*1000 ));
+					// a lookup that times out isn't abandoned - it finishes in the
+					// background and leaves the image in Win32UIEnhancer's pending
+					// cache, which holds it for a minute. backing off past that
+					// window means arriving after the image has been discarded and
+					// starting the whole thing again, so on a file too big to read
+					// inside the timeout the icon never lands. cap the wait below
+					// the window rather than growing indefinitely.
+				
+				long delay = Math.min( fail_count, 2 ) * ( 20*1000 + RandomUtils.nextInt( 5*1000 ));
 				
 				return( elapsed > delay );
 				


### PR DESCRIPTION
A lookup that exceeds getFileIcon's 2.5s timeout is not abandoned: it finishes in the background and leaves the image in Win32UIEnhancer's pending cache, where a later call for the same file picks it up. That cache holds an entry for 60 seconds and a periodic sweep then disposes it.

The retry backoff grows past that window:

    delay = fail_count * ( 30*1000 + rnd( 10*1000 ))   ->  35s, 70s, 105s...

so from the second attempt onwards the retry arrives after the image it was waiting for has been thrown away. It starts a fresh lookup, that one times out too, and the cycle repeats with a longer gap each time. For a file the shell can't read inside the timeout the icon never arrives at all - the work is done every time and discarded every time.

This is reachable with an ordinary large installer: a 590MB .exe on a mechanical disk doesn't finish inside 2.5s, and the row keeps the generic extension icon indefinitely while the same file in the files view - which asks for a different size and got its own lookup in early - is correct.

Capping the backoff below the window means a retry always lands while the image is still there. Two steps is enough to cover a slow first attempt without hammering the queue.