### PR TITLE
Key the torrent thumbnail by completion as well

### DIFF
--- a/uis/src/com/biglybt/ui/swt/utils/TorrentUIUtilsV3.java
+++ b/uis/src/com/biglybt/ui/swt/utils/TorrentUIUtilsV3.java
@@ -349,9 +349,25 @@ public class TorrentUIUtilsV3
 
 		int thumbnailVersion = PlatformTorrentUtils.getContentVersion(torrent);
 
+			// a file that is still being written has no embedded icon yet, so what
+			// the shell hands back is the generic one for the type - a real answer
+			// as far as the lookup is concerned, and cached as such. the icon the
+			// finished file resolves to is a different one, so completion has to
+			// be part of the key or the placeholder is served for good.
+
+		boolean primary_complete;
+
+		{
+			DownloadManager thumb_dm = DataSourceUtils.getDM( datasource );
+
+			DiskManagerFileInfo primary = thumb_dm == null? null: thumb_dm.getDownloadState().getPrimaryFile();
+
+			primary_complete = primary == null || primary.getDownloaded() == primary.getLength();
+		}
+
 			// add torrent size here to differentiate meta-data downloads from actuals
 
-		final String id = "Thumbnail." + hash + "." + torrent.getSize() + "." + thumbnailVersion + (big ? ".big" : "");
+		final String id = "Thumbnail." + hash + "." + torrent.getSize() + "." + thumbnailVersion + (big ? ".big" : "") + (primary_complete ? "" : ".inc");
 
 		Image existing_image = imageLoaderThumb.imageAdded(id) ? imageLoaderThumb.getImage(id) : null;
 		


### PR DESCRIPTION
The thumbnail cache key is built from the hash, size, content version and requested size:

    "Thumbnail." + hash + "." + torrent.getSize() + "." + thumbnailVersion + (big?".big":"")

While the primary file is still being written it has no embedded icon yet, so the shell hands back the generic icon for the type. That's a successful lookup as far as the caller is concerned - not a timeout, not a placeholder - so it gets cached under that key. Once the download finishes the key is unchanged, and the row keeps the generic icon for good.

It shows up as a torrent whose own row stays generic while the files underneath it, which are keyed per file, resolve correctly a moment after completion. Restarting clears it, since the thumbnail cache is in memory.

Adding completion to the key means the finished torrent misses the entry cached while it was incomplete and resolves again, the same way IconFileKey already handles it for the per-file icons.