### PR TITLE
Pass the download's completion state to the thumbnail lookup

### DIFF
--- a/uis/src/com/biglybt/ui/swt/utils/TorrentUIUtilsV3.java
+++ b/uis/src/com/biglybt/ui/swt/utils/TorrentUIUtilsV3.java
@@ -465,7 +465,14 @@ public class TorrentUIUtilsV3
 			// when the real one turns up, refresh the cached thumbnail and
 			// let the listener repaint the cell
 		
+			// pass the completion state through: the five-argument overload
+			// assumes the file is finished, so while it is still being written
+			// the generic icon the shell returns is treated as its real one -
+			// cached in memory and written to the disk cache under the key the
+			// finished file will use, where it survives a restart
+
 		ImageRepository.PathIcon pi = ImageRepository.getPathIcon(path, isFile, big, false,
+				primary_complete,
 				(result)->{
 					Utils.execSWTThread(()->{
 						if ( result != null && !result.temporary ){


### PR DESCRIPTION
getContentImage asks for the primary file's icon through the five-argument getPathIcon, which assumes the file is finished:

    return( getPathIcon( path, isFile, bBig, minifolder, true, icon_listener ));

While the download is still running that's wrong in a way that sticks. The file exists but has no embedded icon yet, so the shell hands back the generic icon for the type - a successful lookup as far as the caller is concerned. It's recorded as PFC_OK under a key that says "complete", and because the key says complete it's also written to the disk cache. The finished download then looks the icon up under the same key and finds the placeholder: in memory for the rest of the session, and on disk across restarts.

Seen with a magnet added and left to download - the row keeps the generic icon indefinitely, and cache/fileicons ends up holding <hash>-32x32x32-big.ico containing the generic executable icon, while the 16x16 entry written later for the files view has the real one.

The completion state is already worked out a few lines above for the thumbnail cache key; this passes it to the lookup as well, so an incomplete file gets its own entry, is never written to disk, and the finished file resolves properly.

The stale check catches entries already written this way on the next run, since the file's timestamp changes when the download completes.