### PR TITLE
Pass the file's completion state from the Full Name column too

### DIFF
--- a/uis/src/com/biglybt/ui/swt/views/tableitems/files/PathNameItem.java
+++ b/uis/src/com/biglybt/ui/swt/views/tableitems/files/PathNameItem.java
@@ -122,7 +122,8 @@ public class PathNameItem extends CoreTableColumnSWT implements
 					if ( Utils.isSWTThread()){
 
 						pi = ImageRepository.getPathIcon(fileInfo.getFile(true).getPath(),
-								true, cell.getHeight() > 32, false);
+								true, cell.getHeight() > 32, false,
+								fileInfo.getDownloaded() == fileInfo.getLength(), null);
 					}else{
 							// happens rarely (seen of filtering of file-view rows
 							// when a new row is added )
@@ -135,7 +136,8 @@ public class PathNameItem extends CoreTableColumnSWT implements
 								run()
 								{
 									ImageRepository.PathIcon pi = ImageRepository.getPathIcon(fileInfo.getFile(true).getPath(),
-													true, _cell.getHeight() > 32, false);
+													true, _cell.getHeight() > 32, false,
+													fileInfo.getDownloaded() == fileInfo.getLength(), null);
 
 									_cell.setIcon( pi.image );
 


### PR DESCRIPTION
PathNameItem asks for the icon through the overload that has no completion flag, so the file is treated as finished regardless:

    pi = ImageRepository.getPathIcon( fileInfo.getFile(true).getPath(),
                                      true, cell.getHeight() > 32, false );

While the file is still being written that means a lookup is made, the shell answers with the generic icon for the type, and the answer is left in Win32UIEnhancer's pending-image cache - which is keyed by path and size only, so the lookup made once the file is finished picks it up and takes it for the real icon.

The column sits in the same table as the Name column, which does pass the flag, and both ask for the same size, so which of them reaches the shell first decides whether the stale answer shows up at all. fileInfo is already to hand, so supplying the flag costs nothing.

The other two callers still on old overloads are fine as they are: mytracker/NameItem passes a relative path out of the torrent's metadata rather than a path on disk, so its cache key can't collide with the real file's, and mytorrents/NameItem already passes the flag.